### PR TITLE
refactor: Replace patch method to put

### DIFF
--- a/src/service/network/bus.ts
+++ b/src/service/network/bus.ts
@@ -140,7 +140,7 @@ export const createBusRoute = async (data: CreateBusRouteRequest) => {
 }
 
 export const updateBusRoute = async (routeID: number, data: UpdateBusRouteRequest) => {
-    return await client.patch(`/api/bus/route/${routeID}`, data)
+    return await client.put(`/api/bus/route/${routeID}`, data)
 }
 
 export const deleteBusRoute = async (routeID: number) => {
@@ -156,7 +156,7 @@ export const createBusStop = async (data: CreateBusStopRequest) => {
 }
 
 export const updateBusStop = async (stopID: number, data: UpdateBusStopRequest) => {
-    return await client.patch(`/api/bus/stop/${stopID}`, data)
+    return await client.put(`/api/bus/stop/${stopID}`, data)
 }
 
 export const deleteBusStop = async (stopID: number) => {
@@ -172,7 +172,7 @@ export const createBusRouteStop = async (routeID: number, data: CreateBusRouteSt
 }
 
 export const updateBusRouteStop = async (routeID: number, stopID: number, data: UpdateBusRouteStopRequest) => {
-    return await client.patch(`/api/bus/route/${routeID}/stop/${stopID}`, data)
+    return await client.put(`/api/bus/route/${routeID}/stop/${stopID}`, data)
 }
 
 export const deleteBusRouteStop = async (routeID: number, stopID: number) => {

--- a/src/service/network/shuttle.ts
+++ b/src/service/network/shuttle.ts
@@ -113,7 +113,7 @@ export const createShuttleRoute = async (data: ShuttleRouteResponse) => {
 }
 
 export const updateShuttleRoute = async (name: string, data: UpdateShuttleRouteRequest) => {
-    return await client.patch(`/api/shuttle/route/${name}`, data)
+    return await client.put(`/api/shuttle/route/${name}`, data)
 }
 
 export const deleteShuttleRoute = async (name: string) => {
@@ -129,7 +129,7 @@ export const createShuttleStop = async (data: ShuttleStopResponse) => {
 }
 
 export const updateShuttleStop = async (name: string, data: UpdateShuttleStopRequest) => {
-    return await client.patch(`/api/shuttle/stop/${name}`, data)
+    return await client.put(`/api/shuttle/stop/${name}`, data)
 }
 
 export const deleteShuttleStop = async (name: string) => {
@@ -145,7 +145,7 @@ export const createShuttleRouteStop = async (routeName: string, data: CreateRout
 }
 
 export const updateShuttleRouteStop = async (routeName: string, stopName: string, data: UpdateShuttleRouteStopRequest) => {
-    return await client.patch(`/api/shuttle/route/${routeName}/stop/${stopName}`, data)
+    return await client.put(`/api/shuttle/route/${routeName}/stop/${stopName}`, data)
 }
 
 export const deleteShuttleRouteStop = async (routeName: string, stopName: string) => {
@@ -161,7 +161,7 @@ export const createShuttleTimetable = async (data: CreateTimetableResponse) => {
 }
 
 export const updateShuttleTimetable = async (sequence: number, data: UpdateShuttleTimetableRequest) => {
-    return await client.patch(`/api/shuttle/timetable/${sequence}`, data)
+    return await client.put(`/api/shuttle/timetable/${sequence}`, data)
 }
 
 export const deleteShuttleTimetable = async (sequence: number) => {

--- a/src/service/network/subway.ts
+++ b/src/service/network/subway.ts
@@ -80,7 +80,7 @@ export const createSubwayRoute = async (data: SubwayRoute) => {
 }
 
 export const updateSubwayRoute = async (routeID: number, data: UpdateSubwayRouteRequest) => {
-    return await client.patch(`/api/subway/route/${routeID}`, data)
+    return await client.put(`/api/subway/route/${routeID}`, data)
 }
 
 export const deleteSubwayRoute = async (routeID: number) => {
@@ -96,7 +96,7 @@ export const createSubwayStation = async (data: SubwayStation) => {
 }
 
 export const updateSubwayStation = async (stationID: string, data: UpdateSubwayStationRequest) => {
-    return await client.patch(`/api/subway/station/${stationID}`, data)
+    return await client.put(`/api/subway/station/${stationID}`, data)
 }
 
 export const deleteSubwayStation = async (stationID: string) => {


### PR DESCRIPTION
## Changes
- Restful API에서 PATCH API의 멱등성이 부족한 단점을 보완하고 CORS 오류를 해결하기 위해 PUT으로 변경