### PR TITLE
feat: Add public holiday management for bus and subway

### DIFF
--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,8 +1,8 @@
 import { createBrowserRouter, Navigate, RouterProvider } from 'react-router-dom'
 
 import Bus from './pages/bus'
-import BusDepartureLog from './pages/bus/log'
 import BusHolidayPage from './pages/bus/holiday'
+import BusDepartureLog from './pages/bus/log'
 import BusRealtime from './pages/bus/realtime'
 import BusRoute from './pages/bus/route'
 import BusRouteStop from './pages/bus/routeStop'

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -2,6 +2,7 @@ import { createBrowserRouter, Navigate, RouterProvider } from 'react-router-dom'
 
 import Bus from './pages/bus'
 import BusDepartureLog from './pages/bus/log'
+import BusHolidayPage from './pages/bus/holiday'
 import BusRealtime from './pages/bus/realtime'
 import BusRoute from './pages/bus/route'
 import BusRouteStop from './pages/bus/routeStop'
@@ -33,6 +34,7 @@ import ShuttleStop from './pages/shuttle/stop'
 import ShuttleTimetable from './pages/shuttle/timetable'
 import ShuttleTimetableView from './pages/shuttle/timetableView'
 import Subway from './pages/subway'
+import SubwayHolidayPage from './pages/subway/holiday'
 import SubwayRealtimePage from './pages/subway/realtime'
 import SubwayRoutePage from './pages/subway/route'
 import SubwayStationPage from './pages/subway/station'
@@ -61,6 +63,7 @@ const appRouter = createBrowserRouter([
                 { path: 'timetable', element: <BusTimetable /> },
                 { path: 'realtime', element: <BusRealtime /> },
                 { path: 'log', element: <BusDepartureLog /> },
+                { path: 'holiday', element: <BusHolidayPage /> },
                 { path: '*', element: <Navigate replace to="/bus/route" /> },
             ] },
             { path: 'subway', element: <Subway />, children: [
@@ -68,6 +71,7 @@ const appRouter = createBrowserRouter([
                 { path: 'route', element: <SubwayRoutePage /> },
                 { path: 'timetable', element: <SubwayTimetablePage /> },
                 { path: 'realtime', element: <SubwayRealtimePage /> },
+                { path: 'holiday', element: <SubwayHolidayPage /> },
             ] },
             { path: 'cafeteria', element: <Cafeteria />, children: [
                 { path: 'cafeteria', element: <CafeteriaPage />  },

--- a/src/routes/pages/bus/holiday/grid.tsx
+++ b/src/routes/pages/bus/holiday/grid.tsx
@@ -1,0 +1,164 @@
+import CancelIcon from '@mui/icons-material/Close'
+import DeleteIcon from '@mui/icons-material/DeleteOutlined'
+import EditIcon from '@mui/icons-material/Edit'
+import SaveIcon from '@mui/icons-material/Save'
+import { Alert, Box, Snackbar } from '@mui/material'
+import {
+    DataGrid,
+    GridActionsCellItem,
+    GridColDef,
+    GridEventListener,
+    GridRowId,
+    GridRowModes,
+    GridRowModesModel,
+} from '@mui/x-data-grid'
+import dayjs from 'dayjs'
+import { useState } from 'react'
+
+import { GridToolbar } from './toolbar.tsx'
+import {
+    createPublicHoliday,
+    deletePublicHoliday,
+    updatePublicHoliday,
+} from '../../../../service/network/publicHoliday.ts'
+import {
+    PublicHoliday,
+    usePublicHolidayGridModelStore,
+    usePublicHolidayStore,
+} from '../../../../stores/publicHoliday.ts'
+
+interface GridProps {
+    columns: GridColDef[]
+}
+
+export const PublicHolidayGrid = (props: GridProps) => {
+    const rowStore = usePublicHolidayStore()
+    const rowModesModelStore = usePublicHolidayGridModelStore()
+    const [errorSnackbarContent, setErrorSnackbarContent] = useState<string>('')
+    const [successSnackbarContent, setSuccessSnackbarContent] = useState<string>('')
+
+    const rowEditStopped: GridEventListener<'rowEditStop'> = (params, event) => {
+        if (event.defaultMuiPrevented) return
+        const editedRow = rowStore.rows.find((row) => row.id === params.id)
+        if (editedRow!.isNew) {
+            rowStore.setRows(rowStore.rows.map((row) =>
+                row.id === params.id ? { ...row, isNew: false } : row
+            ))
+        }
+    }
+
+    const editRowButtonClicked = (id: GridRowId) => {
+        rowModesModelStore.setRowModesModel({ ...rowModesModelStore.rowModesModel, [id]: { mode: GridRowModes.Edit } })
+    }
+    const saveRowButtonClicked = (id: GridRowId) => {
+        rowModesModelStore.setRowModesModel({ ...rowModesModelStore.rowModesModel, [id]: { mode: GridRowModes.View } })
+    }
+    const deleteRowButtonClicked = async (id: GridRowId) => {
+        const rowToDelete = rowStore.rows.find((row) => row.id === id)
+        if (rowToDelete === undefined) { setErrorSnackbarContent('데이터 삭제에 실패했습니다.'); return }
+        const response = await deletePublicHoliday(rowToDelete.seq!)
+        if (response.status !== 204) { setErrorSnackbarContent('데이터 삭제에 실패했습니다.'); return }
+        setSuccessSnackbarContent('데이터 삭제에 성공했습니다.')
+        rowStore.setRows(rowStore.rows.filter((row) => row.id !== id))
+    }
+    const cancelRowButtonClicked = (id: GridRowId) => {
+        rowModesModelStore.setRowModesModel({
+            ...rowModesModelStore.rowModesModel,
+            [id]: { mode: GridRowModes.View, ignoreModifications: true },
+        })
+        const editedRow = rowStore.rows.find((row) => row.id === id)
+        if (editedRow!.isNew) {
+            rowStore.setRows(rowStore.rows.filter((row) => row.id !== id))
+        }
+    }
+    const updateRowProcess = async (newRow: PublicHoliday) => {
+        if (!newRow.name || !newRow.calendarType || !newRow.date) {
+            setErrorSnackbarContent('올바른 데이터가 아닙니다.')
+            rowStore.setRows(rowStore.rows.filter((row) => row.id !== newRow.id))
+            return { ...newRow, _action: 'delete' }
+        }
+        if (!newRow.isNew && newRow.seq !== null) {
+            const response = await updatePublicHoliday(newRow.seq, {
+                name: newRow.name!,
+                calendarType: newRow.calendarType!,
+                date: dayjs(newRow.date).format('YYYY-MM-DD'),
+            })
+            if (response.status !== 200) { setErrorSnackbarContent('데이터 저장에 실패했습니다.'); return { ...newRow, _action: 'revert' } }
+            setSuccessSnackbarContent('데이터 저장에 성공했습니다.')
+            return newRow
+        } else {
+            const response = await createPublicHoliday({
+                name: newRow.name!,
+                calendarType: newRow.calendarType!,
+                date: dayjs(newRow.date).format('YYYY-MM-DD'),
+            })
+            if (response.status !== 201) {
+                setErrorSnackbarContent('데이터 저장에 실패했습니다.')
+                rowStore.setRows(rowStore.rows.filter((row) => row.id !== newRow.id))
+                return { ...newRow, _action: 'delete' }
+            }
+            setSuccessSnackbarContent('데이터 저장에 성공했습니다.')
+            const updatedRow = { ...newRow, isNew: false, seq: response.data.seq }
+            rowStore.setRows(rowStore.rows.map((row) => row.id === newRow.id ? updatedRow : row))
+            return updatedRow
+        }
+    }
+    const rowModesModelChanged = (newRowModesModel: GridRowModesModel) => {
+        rowModesModelStore.setRowModesModel(newRowModesModel)
+    }
+
+    props.columns.push({
+        field: 'actions',
+        headerName: '동작',
+        type: 'actions',
+        width: 100,
+        cellClassName: 'actions',
+        getActions: ({ id }) => {
+            const isEditing = rowModesModelStore.rowModesModel[id]?.mode === GridRowModes.Edit
+            if (isEditing) {
+                return [
+                    <GridActionsCellItem label="save" key="save" icon={<SaveIcon />} onClick={() => saveRowButtonClicked(id)} />,
+                    <GridActionsCellItem label="cancel" key="cancel" icon={<CancelIcon />} onClick={() => cancelRowButtonClicked(id)} />,
+                ]
+            }
+            return [
+                <GridActionsCellItem label="edit" key="edit" icon={<EditIcon />} onClick={() => editRowButtonClicked(id)} />,
+                <GridActionsCellItem label="delete" key="delete" icon={<DeleteIcon />} onClick={() => deleteRowButtonClicked(id)} />,
+            ]
+        },
+    })
+
+    return (
+        <Box sx={{ height: '90vh', width: '100%' }}>
+            <Snackbar
+                anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+                open={errorSnackbarContent !== ''}
+                autoHideDuration={3000}
+                onClose={() => setErrorSnackbarContent('')}>
+                <Alert onClose={() => setErrorSnackbarContent('')} severity="error" sx={{ width: '100%' }}>
+                    {errorSnackbarContent}
+                </Alert>
+            </Snackbar>
+            <Snackbar
+                anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+                open={successSnackbarContent !== ''}
+                autoHideDuration={3000}
+                onClose={() => setSuccessSnackbarContent('')}>
+                <Alert onClose={() => setSuccessSnackbarContent('')} severity="success" sx={{ width: '100%' }}>
+                    {successSnackbarContent}
+                </Alert>
+            </Snackbar>
+            <DataGrid
+                showToolbar={true}
+                columns={props.columns}
+                rows={rowStore.rows}
+                rowModesModel={rowModesModelStore.rowModesModel}
+                editMode="row"
+                onRowModesModelChange={rowModesModelChanged}
+                onRowEditStop={rowEditStopped}
+                processRowUpdate={updateRowProcess}
+                slots={{ toolbar: GridToolbar }}
+            />
+        </Box>
+    )
+}

--- a/src/routes/pages/bus/holiday/index.tsx
+++ b/src/routes/pages/bus/holiday/index.tsx
@@ -1,0 +1,69 @@
+import { GridColDef } from '@mui/x-data-grid'
+import dayjs from 'dayjs'
+import { useEffect } from 'react'
+import { v4 as uuidv4 } from 'uuid'
+
+import { PublicHolidayGrid } from './grid.tsx'
+import { getPublicHoliday, PublicHolidayResponse } from '../../../../service/network/publicHoliday.ts'
+import { usePublicHolidayStore } from '../../../../stores/publicHoliday.ts'
+
+export default function PublicHolidayPage() {
+    const store = usePublicHolidayStore()
+    const fetchData = async () => {
+        const response = await getPublicHoliday()
+        if (response.status === 200) {
+            store.setRows(response.data.result.map((item: PublicHolidayResponse) => ({
+                id: uuidv4(),
+                seq: item.seq,
+                name: item.name,
+                calendarType: item.calendarType,
+                date: dayjs(item.date).toDate(),
+            })))
+        }
+    }
+    useEffect(() => { fetchData().catch(console.error) }, [])
+
+    const calendarTypeValueFormatter = (value: string) => {
+        switch (value) {
+        case 'solar': return '양력'
+        case 'lunar': return '음력'
+        default: return '기타'
+        }
+    }
+    const columns: GridColDef[] = [
+        {
+            field: 'date',
+            headerName: '날짜',
+            minWidth: 200,
+            flex: 1,
+            valueFormatter: (value: Date) => dayjs(value).format('YYYY-MM-DD'),
+            type: 'date',
+            editable: true,
+            headerAlign: 'center',
+            align: 'center',
+        },
+        {
+            field: 'calendarType',
+            headerName: '음력/양력',
+            minWidth: 150,
+            flex: 1,
+            valueFormatter: calendarTypeValueFormatter,
+            type: 'singleSelect',
+            valueOptions: ['solar', 'lunar'],
+            editable: true,
+            headerAlign: 'center',
+            align: 'center',
+        },
+        {
+            field: 'name',
+            headerName: '공휴일 이름',
+            minWidth: 200,
+            flex: 2,
+            editable: true,
+            headerAlign: 'center',
+            align: 'center',
+        },
+    ]
+
+    return <PublicHolidayGrid columns={columns} />
+}

--- a/src/routes/pages/bus/holiday/toolbar.tsx
+++ b/src/routes/pages/bus/holiday/toolbar.tsx
@@ -1,0 +1,54 @@
+import AddIcon from '@mui/icons-material/Add'
+import RefreshIcon from '@mui/icons-material/Refresh'
+import { GridRowModes, Toolbar, ToolbarButton } from '@mui/x-data-grid'
+import dayjs from 'dayjs'
+import { v4 as uuidv4 } from 'uuid'
+
+import { getPublicHoliday, PublicHolidayResponse } from '../../../../service/network/publicHoliday.ts'
+import { usePublicHolidayGridModelStore, usePublicHolidayStore } from '../../../../stores/publicHoliday.ts'
+
+export const GridToolbar = () => {
+    const rowStore = usePublicHolidayStore()
+    const rowModesModelStore = usePublicHolidayGridModelStore()
+    const fetchPublicHoliday = async () => {
+        const response = await getPublicHoliday()
+        if (response.status === 200) {
+            rowStore.setRows(response.data.result.map((item: PublicHolidayResponse) => ({
+                id: uuidv4(),
+                seq: item.seq,
+                name: item.name,
+                calendarType: item.calendarType,
+                date: dayjs(item.date),
+            })))
+        }
+    }
+    const addRowButtonClicked = () => {
+        const id = uuidv4()
+        rowStore.setRows([
+            {
+                id,
+                seq: null,
+                name: '',
+                calendarType: '',
+                date: null,
+                isNew: true,
+            },
+            ...rowStore.rows,
+        ])
+        rowModesModelStore.setRowModesModel({
+            ...rowModesModelStore.rowModesModel,
+            [id]: { mode: GridRowModes.Edit, fieldToFocus: 'name' },
+        })
+    }
+
+    return (
+        <Toolbar>
+            <ToolbarButton onClick={fetchPublicHoliday}>
+                <RefreshIcon />
+            </ToolbarButton>
+            <ToolbarButton onClick={addRowButtonClicked}>
+                <AddIcon />
+            </ToolbarButton>
+        </Toolbar>
+    )
+}

--- a/src/routes/pages/bus/index.tsx
+++ b/src/routes/pages/bus/index.tsx
@@ -25,6 +25,7 @@ export default function Bus() {
                     <Tab label="시간표 관리" value="timetable" />
                     <Tab label="실시간 도착 정보" value="realtime" />
                     <Tab label="도착 기록" value="log" />
+                    <Tab label="공휴일 관리" value="holiday" />
                 </Tabs>
             </Box>
             <Outlet />

--- a/src/routes/pages/subway/holiday/index.tsx
+++ b/src/routes/pages/subway/holiday/index.tsx
@@ -1,1 +1,1 @@
-export { default } from '../bus/holiday/index.tsx'
+export { default } from '../bus/holiday'

--- a/src/routes/pages/subway/holiday/index.tsx
+++ b/src/routes/pages/subway/holiday/index.tsx
@@ -1,0 +1,1 @@
+export { default } from '../bus/holiday/index.tsx'

--- a/src/routes/pages/subway/holiday/index.tsx
+++ b/src/routes/pages/subway/holiday/index.tsx
@@ -1,1 +1,3 @@
-export { default } from '../bus/holiday'
+import PublicHolidayPage from '../../bus/holiday/index.tsx'
+
+export default PublicHolidayPage

--- a/src/routes/pages/subway/index.tsx
+++ b/src/routes/pages/subway/index.tsx
@@ -23,6 +23,7 @@ export default function Subway() {
                     <Tab label="전철역 관리" value="station" />
                     <Tab label="시간표 관리" value="timetable" />
                     <Tab label="실시간 도착 정보" value="realtime" />
+                    <Tab label="공휴일 관리" value="holiday" />
                 </Tabs>
             </Box>
             <Outlet />

--- a/src/service/network/publicHoliday.ts
+++ b/src/service/network/publicHoliday.ts
@@ -1,0 +1,30 @@
+import client from './index.ts'
+
+export type PublicHolidayResponse = {
+    seq: number,
+    name: string,
+    calendarType: string,
+    date: string,
+}
+
+export type PublicHolidayRequest = {
+    name: string,
+    calendarType: string,
+    date: string,
+}
+
+export const getPublicHoliday = async () => {
+    return await client.get('/api/v1/holiday')
+}
+
+export const createPublicHoliday = async (data: PublicHolidayRequest) => {
+    return await client.post('/api/v1/holiday', data)
+}
+
+export const updatePublicHoliday = async (seq: number, data: PublicHolidayRequest) => {
+    return await client.put(`/api/v1/holiday/${seq}`, data)
+}
+
+export const deletePublicHoliday = async (seq: number) => {
+    return await client.delete(`/api/v1/holiday/${seq}`)
+}

--- a/src/service/network/publicHoliday.ts
+++ b/src/service/network/publicHoliday.ts
@@ -1,4 +1,4 @@
-import client from './index.ts'
+import client from './client'
 
 export type PublicHolidayResponse = {
     seq: number,

--- a/src/stores/publicHoliday.ts
+++ b/src/stores/publicHoliday.ts
@@ -1,0 +1,42 @@
+import { GridRowModesModel } from '@mui/x-data-grid'
+import { create } from 'zustand'
+import { devtools } from 'zustand/middleware'
+
+import { GridModelStore } from './index.ts'
+
+export type PublicHoliday = {
+    id: string,
+    seq: number | null,
+    name: string | null,
+    calendarType: string | null,
+    date: Date | null,
+    isNew: boolean,
+}
+
+type PublicHolidayStore = {
+    rows: Array<PublicHoliday>,
+    setRows: (rows: Array<PublicHoliday>) => void,
+}
+
+export const usePublicHolidayStore = create(
+    devtools<PublicHolidayStore>(
+        (set) => ({
+            rows: [],
+            setRows: (rows: Array<PublicHoliday>) => {
+                rows.sort((a, b) => (a.date! < b.date! ? -1 : a.date! > b.date! ? 1 : 0))
+                set({ rows })
+            },
+        }),
+        { name: 'PublicHolidayStore' }
+    )
+)
+
+export const usePublicHolidayGridModelStore = create(
+    devtools<GridModelStore>(
+        (set) => ({
+            rowModesModel: {},
+            setRowModesModel: (rowModesModel: GridRowModesModel) => set({ rowModesModel }),
+        }),
+        { name: 'PublicHolidayGridModelStore' }
+    )
+)


### PR DESCRIPTION
## Changes
- 버스/전철 공통 공휴일 관리 페이지 추가 (`/bus/holiday`, `/subway/holiday`)
- 두 경로 모두 동일한 `public_holiday` 테이블을 관리하는 컴포넌트 공유
- 공휴일 이름, 날짜(양력/음력), CRUD 기능 제공
- Zustand 스토어(`publicHoliday.ts`) 및 네트워크 서비스(`publicHoliday.ts`) 추가