### PR TITLE
fix: Align shuttle timetable weekday fields

### DIFF
--- a/src/routes/pages/shuttle/timetable/grid.tsx
+++ b/src/routes/pages/shuttle/timetable/grid.tsx
@@ -80,7 +80,7 @@ export const ShuttleTimetableGrid = (props: GridProps) => {
             const response = await createShuttleTimetable(
                 rowStore.selectedRoute!, {
                     period: newRow.period,
-                    weekdays: newRow.weekdays,
+                    weekday: newRow.weekdays,
                     departureTime: newRow.time,
                 }
             )
@@ -90,14 +90,14 @@ export const ShuttleTimetableGrid = (props: GridProps) => {
                 return { ...newRow, _action: 'delete' }
             }
             const responseData = response.data
-            const updatedRow = { ...newRow, sequence: responseData.sequence, isNew: false }
+            const updatedRow = { ...newRow, seq: responseData.seq, isNew: false }
             setSuccessSnackbarContent('데이터 저장에 성공했습니다.')
             rowStore.setRows(rowStore.rows.map((row) => row.id === newRow.id ? updatedRow : row))
             return updatedRow
         } else if (newRow.seq !== null) {
             const response = await updateShuttleTimetable(rowStore.selectedRoute!, newRow.seq, {
                 period: newRow.period,
-                weekdays: newRow.weekdays,
+                weekday: newRow.weekdays,
                 departureTime: newRow.time,
             })
             if (response.status !== 200) {

--- a/src/routes/pages/shuttle/timetable/toolbar.tsx
+++ b/src/routes/pages/shuttle/timetable/toolbar.tsx
@@ -45,7 +45,7 @@ export const GridToolbar = () => {
                     id: uuidv4(),
                     seq: item.seq,
                     period: item.period,
-                    weekdays: item.weekdays,
+                    weekdays: item.isWeekdays,
                     time: item.departureTime,
                 }
             }))

--- a/src/service/network/shuttle.ts
+++ b/src/service/network/shuttle.ts
@@ -90,20 +90,20 @@ export type UpdateShuttleRouteStopRequest = {
 export type ShuttleTimetableResponse = {
     seq: number,
     period: string,
-    weekdays: boolean,
+    isWeekdays: boolean,
     route: string,
     departureTime: string,
 }
 
 export type CreateTimetableRequest = {
     period: string,
-    weekdays: boolean,
+    weekday: boolean,
     departureTime: string,
 }
 
 export type UpdateShuttleTimetableRequest = {
     period: string,
-    weekdays: boolean,
+    weekday: boolean,
     departureTime: string,
 }
 


### PR DESCRIPTION
## Changes
- 셔틀버스 시간표 생성/수정 요청의 평일 여부 필드를 백엔드 API 계약에 맞게 `weekday`로 전송
- 셔틀버스 시간표 조회 응답의 `isWeekdays` 필드를 그리드 row 상태에 매핑
- 시간표 생성 성공 후 응답의 `seq`를 row에 저장해 후속 수정/삭제가 가능하도록 보정

## Validation
- `yarn lint`
- `yarn build`