### PR TITLE
feat: Add admin permission management

### DIFF
--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,5 +1,7 @@
 import { createBrowserRouter, Navigate, RouterProvider } from 'react-router-dom'
 
+import AccessDenied from './pages/accessDenied.tsx'
+import AdminUsers from './pages/admin/users.tsx'
 import Bus from './pages/bus'
 import BusHolidayPage from './pages/bus/holiday'
 import BusDepartureLog from './pages/bus/log'
@@ -40,6 +42,7 @@ import SubwayRealtimePage from './pages/subway/realtime'
 import SubwayRoutePage from './pages/subway/route'
 import SubwayStationPage from './pages/subway/station'
 import SubwayTimetablePage from './pages/subway/timetable'
+import { PermissionLanding, PermissionRoute } from './permissionRoute.tsx'
 
 const appRouter = createBrowserRouter([
     { path: '*', element: <Navigate replace to="/" /> },
@@ -47,7 +50,7 @@ const appRouter = createBrowserRouter([
         path: '/',
         element: <Home />,
         children: [
-            { path: 'shuttle', element: <Shuttle />, children: [
+            { path: 'shuttle', element: <PermissionRoute permission='SHUTTLE'><Shuttle /></PermissionRoute>, children: [
                 { path: 'period', element: <Period /> },
                 { path: 'holiday', element: <Holiday /> },
                 { path: 'route', element: <ShuttleRoute /> },
@@ -57,7 +60,7 @@ const appRouter = createBrowserRouter([
                 { path: 'timetableView', element: <ShuttleTimetableView /> },
                 { path: '*', element: <Navigate replace to="/shuttle/period" /> },
             ] },
-            { path: 'bus', element: <Bus />, children: [
+            { path: 'bus', element: <PermissionRoute permission='BUS'><Bus /></PermissionRoute>, children: [
                 { path: 'route', element: <BusRoute /> },
                 { path: 'stop', element: <BusStop /> },
                 { path: 'routeStop', element: <BusRouteStop /> },
@@ -67,36 +70,38 @@ const appRouter = createBrowserRouter([
                 { path: 'holiday', element: <BusHolidayPage /> },
                 { path: '*', element: <Navigate replace to="/bus/route" /> },
             ] },
-            { path: 'subway', element: <Subway />, children: [
+            { path: 'subway', element: <PermissionRoute permission='SUBWAY'><Subway /></PermissionRoute>, children: [
                 { path: 'station', element: <SubwayStationPage /> },
                 { path: 'route', element: <SubwayRoutePage /> },
                 { path: 'timetable', element: <SubwayTimetablePage /> },
                 { path: 'realtime', element: <SubwayRealtimePage /> },
                 { path: 'holiday', element: <SubwayHolidayPage /> },
             ] },
-            { path: 'cafeteria', element: <Cafeteria />, children: [
+            { path: 'cafeteria', element: <PermissionRoute permission='CAFETERIA'><Cafeteria /></PermissionRoute>, children: [
                 { path: 'cafeteria', element: <CafeteriaPage />  },
                 { path: 'menu', element: <CafeteriaMenuPage />  },
             ] },
-            { path: 'readingRoom', element: <ReadingRoom />, children: [
+            { path: 'readingRoom', element: <PermissionRoute permission='READING_ROOM'><ReadingRoom /></PermissionRoute>, children: [
                 { path: 'room', element: <ReadingRoomPage /> },
             ] },
-            { path: 'contact', element: <Contact />, children: [
+            { path: 'contact', element: <PermissionRoute permission='CONTACT'><Contact /></PermissionRoute>, children: [
                 { path: 'category', element: <ContactCategoryPage /> },
                 { path: 'seoul', element: <SeoulContactPage /> },
                 { path: 'erica', element: <ERICAContactPage /> },
             ] },
-            { path: 'calendar', element: <Calendar />, children: [
+            { path: 'calendar', element: <PermissionRoute permission='CALENDAR'><Calendar /></PermissionRoute>, children: [
                 { path: 'category', element: <CalendarCategoryPage /> },
                 { path: 'event', element: <CalendarEventPage /> }
             ] },
-            { path: 'notice', element: <Notice />, children: [
+            { path: 'notice', element: <PermissionRoute permission='NOTICE'><Notice /></PermissionRoute>, children: [
                 { path: 'category', element: <NoticeCategoryPage /> },
                 { path: 'notice', element: <NoticePage /> },
             ] },
-            { path: 'settings', element: <Settings /> },
-            { path: '/', element: <Navigate replace to="/shuttle/period" /> },
-            { path: '*', element: <Navigate replace to="/shuttle/period" /> },
+            { path: 'settings', element: <PermissionRoute permission='BUS'><Settings /></PermissionRoute> },
+            { path: 'admin/users', element: <PermissionRoute permission='SUPER_ADMIN'><AdminUsers /></PermissionRoute> },
+            { path: 'access-denied', element: <AccessDenied /> },
+            { index: true, element: <PermissionLanding /> },
+            { path: '*', element: <PermissionLanding /> },
         ]
     },
     { path: '/login', element: <Login /> },

--- a/src/routes/pages/accessDenied.tsx
+++ b/src/routes/pages/accessDenied.tsx
@@ -1,0 +1,20 @@
+import LockOutlinedIcon from '@mui/icons-material/LockOutlined'
+import { Box, Paper, Typography } from '@mui/material'
+
+export default function AccessDenied() {
+    return (
+        <Box sx={{ p: { xs: 2, sm: 3 }, display: 'flex', justifyContent: 'center' }}>
+            <Paper
+                variant='outlined'
+                sx={{ p: 4, maxWidth: 520, width: '100%', textAlign: 'center', borderRadius: 3 }}>
+                <LockOutlinedIcon color='disabled' sx={{ fontSize: 52, mb: 2 }} />
+                <Typography variant='h5' fontWeight={700} gutterBottom>
+                    관리 권한이 없습니다
+                </Typography>
+                <Typography color='text.secondary'>
+                    필요한 관리 영역을 사용할 수 있도록 최고 관리자에게 권한을 요청해 주세요.
+                </Typography>
+            </Paper>
+        </Box>
+    )
+}

--- a/src/routes/pages/admin/users.tsx
+++ b/src/routes/pages/admin/users.tsx
@@ -1,0 +1,280 @@
+import AdminPanelSettingsOutlinedIcon from '@mui/icons-material/AdminPanelSettingsOutlined'
+import PersonOffOutlinedIcon from '@mui/icons-material/PersonOffOutlined'
+import SaveOutlinedIcon from '@mui/icons-material/SaveOutlined'
+import SearchIcon from '@mui/icons-material/Search'
+import {
+    Alert,
+    Avatar,
+    Box,
+    Button,
+    Card,
+    CardContent,
+    CardHeader,
+    Checkbox,
+    Chip,
+    CircularProgress,
+    Divider,
+    FormControl,
+    FormControlLabel,
+    FormGroup,
+    FormLabel,
+    InputAdornment,
+    Snackbar,
+    Switch,
+    TextField,
+    Typography,
+} from '@mui/material'
+import axios from 'axios'
+import { useEffect, useMemo, useState } from 'react'
+
+import {
+    MANAGEMENT_PERMISSIONS,
+} from '../../../security/permissions.ts'
+import type { AdminPermission } from '../../../security/permissions.ts'
+import {
+    getAdminUsers,
+    updateAdminUser,
+} from '../../../service/network/adminUsers.ts'
+import type { AdminUser } from '../../../service/network/adminUsers.ts'
+
+type UserDraft = Pick<AdminUser, 'active' | 'permissions'>
+
+const sameDraft = (user: AdminUser, draft: UserDraft) =>
+    user.active === draft.active &&
+    [...user.permissions].sort().join(',') === [...draft.permissions].sort().join(',')
+
+export default function AdminUsers() {
+    const [users, setUsers] = useState<AdminUser[]>([])
+    const [drafts, setDrafts] = useState<Record<string, UserDraft>>({})
+    const [query, setQuery] = useState('')
+    const [loading, setLoading] = useState(true)
+    const [savingUser, setSavingUser] = useState<string | null>(null)
+    const [error, setError] = useState<string | null>(null)
+    const [saved, setSaved] = useState(false)
+
+    const loadUsers = async () => {
+        setLoading(true)
+        try {
+            const response = await getAdminUsers()
+            setUsers(response.data.result)
+            setDrafts(Object.fromEntries(response.data.result.map((user) => [
+                user.username,
+                { active: user.active, permissions: [...user.permissions] },
+            ])))
+            setError(null)
+        } catch {
+            setError('관리자 계정 목록을 불러오지 못했습니다.')
+        } finally {
+            setLoading(false)
+        }
+    }
+
+    useEffect(() => {
+        void loadUsers()
+    }, [])
+
+    const filteredUsers = useMemo(() => {
+        const normalizedQuery = query.trim().toLocaleLowerCase()
+        if (!normalizedQuery) return users
+        return users.filter((user) =>
+            [user.username, user.nickname, user.email]
+                .some((value) => value.toLocaleLowerCase().includes(normalizedQuery)))
+    }, [query, users])
+
+    const updateDraft = (username: string, update: Partial<UserDraft>) => {
+        setDrafts((current) => ({
+            ...current,
+            [username]: { ...current[username], ...update },
+        }))
+    }
+
+    const togglePermission = (username: string, permission: AdminPermission) => {
+        const current = drafts[username]
+        const next = current.permissions.includes(permission)
+            ? current.permissions.filter((item) => item !== permission)
+            : [...current.permissions, permission]
+        updateDraft(username, { permissions: next })
+    }
+
+    const saveUser = async (user: AdminUser) => {
+        const draft = drafts[user.username]
+        setSavingUser(user.username)
+        try {
+            const response = await updateAdminUser(user.username, draft)
+            setUsers((current) => current.map((item) =>
+                item.username === user.username ? response.data : item))
+            setDrafts((current) => ({
+                ...current,
+                [user.username]: {
+                    active: response.data.active,
+                    permissions: [...response.data.permissions],
+                },
+            }))
+            setError(null)
+            setSaved(true)
+        } catch (requestError: unknown) {
+            const isLastSuperAdmin = axios.isAxiosError<{ message?: string }>(requestError) &&
+                requestError.response?.data?.message === 'LAST_SUPER_ADMIN_REQUIRED'
+            const message = isLastSuperAdmin
+                ? '활성화된 최고 관리자는 최소 한 명 이상 필요합니다.'
+                : '권한 변경을 저장하지 못했습니다.'
+            setError(message)
+        } finally {
+            setSavingUser(null)
+        }
+    }
+
+    return (
+        <Box sx={{
+            p: { xs: 2, md: 3 },
+            width: '100%',
+            maxWidth: 1180,
+            mx: 'auto',
+            boxSizing: 'border-box',
+            minWidth: 0,
+        }}>
+            <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 2, mb: 3 }}>
+                <Avatar sx={{ bgcolor: 'primary.main', width: 48, height: 48 }}>
+                    <AdminPanelSettingsOutlinedIcon />
+                </Avatar>
+                <Box>
+                    <Typography variant='h4' component='h1' fontWeight={750}>
+                        사용자 및 권한
+                    </Typography>
+                    <Typography color='text.secondary' sx={{ mt: 0.5 }}>
+                        계정을 활성화하고 담당할 관리 영역을 지정합니다.
+                    </Typography>
+                </Box>
+            </Box>
+
+            <Alert severity='info' sx={{ mb: 3 }}>
+                최고 관리자는 모든 영역과 사용자 권한을 관리할 수 있습니다. 일반 관리자에게는 필요한 영역만 부여하세요.
+            </Alert>
+
+            {error && <Alert severity='error' sx={{ mb: 3 }} onClose={() => setError(null)}>{error}</Alert>}
+
+            <TextField
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                label='사용자 검색'
+                placeholder='이름, 아이디 또는 이메일'
+                fullWidth
+                sx={{ mb: 3, maxWidth: 520 }}
+                slotProps={{
+                    input: {
+                        startAdornment: (
+                            <InputAdornment position='start'><SearchIcon /></InputAdornment>
+                        ),
+                    },
+                }}
+            />
+
+            {loading ? (
+                <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+                    <CircularProgress aria-label='관리자 계정 불러오는 중' />
+                </Box>
+            ) : filteredUsers.length === 0 ? (
+                <Box sx={{ textAlign: 'center', py: 8, color: 'text.secondary' }}>
+                    <PersonOffOutlinedIcon sx={{ fontSize: 48, mb: 1 }} />
+                    <Typography>검색 결과가 없습니다.</Typography>
+                </Box>
+            ) : (
+                <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', lg: 'repeat(2, 1fr)' }, gap: 2.5 }}>
+                    {filteredUsers.map((user) => {
+                        const draft = drafts[user.username]
+                        const isSuperAdmin = draft.permissions.includes('SUPER_ADMIN')
+                        const isSaving = savingUser === user.username
+                        return (
+                            <Card key={user.username} variant='outlined' sx={{ borderRadius: 3 }}>
+                                <CardHeader
+                                    avatar={<Avatar>{user.nickname.slice(0, 1)}</Avatar>}
+                                    title={user.nickname}
+                                    subheader={`${user.username} · ${user.email}`}
+                                    action={
+                                        <Chip
+                                            label={draft.active ? '활성' : '비활성'}
+                                            color={draft.active ? 'success' : 'default'}
+                                            size='small'
+                                            sx={{ mt: 1 }}
+                                        />
+                                    }
+                                />
+                                <CardContent sx={{ pt: 0 }}>
+                                    <FormControlLabel
+                                        sx={{ minHeight: 48, mx: 0, width: '100%' }}
+                                        control={
+                                            <Switch
+                                                checked={draft.active}
+                                                onChange={(event) => updateDraft(user.username, { active: event.target.checked })}
+                                                slotProps={{ input: { 'aria-label': `${user.nickname} 계정 활성화` } }}
+                                            />
+                                        }
+                                        label='로그인 및 관리 기능 사용 허용'
+                                    />
+                                    <Divider sx={{ my: 2 }} />
+                                    <FormControl component='fieldset' fullWidth>
+                                        <FormLabel component='legend' sx={{ mb: 1, color: 'text.primary', fontWeight: 700 }}>
+                                            권한 수준
+                                        </FormLabel>
+                                        <FormControlLabel
+                                            sx={{ minHeight: 48, mx: 0 }}
+                                            control={
+                                                <Checkbox
+                                                    checked={isSuperAdmin}
+                                                    onChange={() => togglePermission(user.username, 'SUPER_ADMIN')}
+                                                />
+                                            }
+                                            label='최고 관리자'
+                                        />
+                                        <FormLabel component='legend' sx={{ mt: 2, mb: 1, color: 'text.primary', fontWeight: 700 }}>
+                                            관리 영역
+                                        </FormLabel>
+                                        <FormGroup
+                                            sx={{
+                                                display: 'grid',
+                                                gridTemplateColumns: { xs: '1fr 1fr', sm: 'repeat(4, 1fr)' },
+                                                gap: 0.5,
+                                            }}>
+                                            {MANAGEMENT_PERMISSIONS.map(({ value, label }) => (
+                                                <FormControlLabel
+                                                    key={value}
+                                                    sx={{ minHeight: 48, mx: 0, opacity: isSuperAdmin ? 0.65 : 1 }}
+                                                    control={
+                                                        <Checkbox
+                                                            checked={isSuperAdmin || draft.permissions.includes(value)}
+                                                            disabled={isSuperAdmin}
+                                                            onChange={() => togglePermission(user.username, value)}
+                                                        />
+                                                    }
+                                                    label={label}
+                                                />
+                                            ))}
+                                        </FormGroup>
+                                    </FormControl>
+                                    <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: 2 }}>
+                                        <Button
+                                            variant='contained'
+                                            startIcon={isSaving ? <CircularProgress size={18} color='inherit' /> : <SaveOutlinedIcon />}
+                                            disabled={isSaving || sameDraft(user, draft)}
+                                            onClick={() => saveUser(user)}
+                                            sx={{ minHeight: 44 }}>
+                                            저장
+                                        </Button>
+                                    </Box>
+                                </CardContent>
+                            </Card>
+                        )
+                    })}
+                </Box>
+            )}
+
+            <Snackbar
+                open={saved}
+                autoHideDuration={3000}
+                onClose={() => setSaved(false)}
+                message='사용자 권한을 저장했습니다.'
+                anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+            />
+        </Box>
+    )
+}

--- a/src/routes/pages/home.tsx
+++ b/src/routes/pages/home.tsx
@@ -1,3 +1,4 @@
+import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings'
 import CalendarMonthIcon from '@mui/icons-material/CalendarMonth'
 import CampaignIcon from '@mui/icons-material/Campaign'
 import ContactsIcon from '@mui/icons-material/Contacts'
@@ -24,6 +25,8 @@ import {
 import { createElement, useEffect } from 'react'
 import { Outlet, useNavigate } from 'react-router-dom'
 
+import { hasPermission } from '../../security/permissions.ts'
+import type { AdminPermission } from '../../security/permissions.ts'
 import { getUserInfo, logout } from '../../service/network/auth.ts'
 import { useAuthenticatedStore, useUserInfoStore } from '../../stores/auth.ts'
 import { useDrawerOpenedStore } from '../../stores/home.ts'
@@ -37,7 +40,6 @@ export default function Home() {
     // Fetch user info
     const fetchUserInfo = async () => {
         const response = await getUserInfo()
-        isAuthenticatedStore.setIsAuthenticated(response.status === 200)
         if (response.status === 200) {
             const responseData = response.data
             userInfoStore.setUserInfo(
@@ -45,8 +47,10 @@ export default function Home() {
                 responseData.nickname,
                 responseData.email,
                 responseData.phone,
+                responseData.permissions,
             )
         }
+        isAuthenticatedStore.setIsAuthenticated(response.status === 200)
     }
     // Logout
     const logOutButtonClicked = async () => {
@@ -106,30 +110,27 @@ export default function Home() {
     )
     // Drawer
     const navigate = useNavigate()
-    const menuTexts = ['셔틀버스', '노선버스', '전철', '학식', '열람실', '연락처', '학사일정', '공지사항', '설정']
-    const menuIcons = [
-        DepartureBoardIcon,
-        DirectionsBusIcon,
-        DirectionsSubwayIcon,
-        DiningIcon,
-        LibraryBooksIcon,
-        ContactsIcon,
-        CalendarMonthIcon,
-        CampaignIcon,
-        SettingsIcon,
+    const allMenuItems: Array<{
+        text: string,
+        path: string,
+        permission: AdminPermission,
+        icon: typeof DepartureBoardIcon,
+    }> = [
+        { text: '셔틀버스', path: '/shuttle', permission: 'SHUTTLE', icon: DepartureBoardIcon },
+        { text: '노선버스', path: '/bus', permission: 'BUS', icon: DirectionsBusIcon },
+        { text: '전철', path: '/subway', permission: 'SUBWAY', icon: DirectionsSubwayIcon },
+        { text: '학식', path: '/cafeteria', permission: 'CAFETERIA', icon: DiningIcon },
+        { text: '열람실', path: '/readingRoom', permission: 'READING_ROOM', icon: LibraryBooksIcon },
+        { text: '연락처', path: '/contact', permission: 'CONTACT', icon: ContactsIcon },
+        { text: '학사일정', path: '/calendar', permission: 'CALENDAR', icon: CalendarMonthIcon },
+        { text: '공지사항', path: '/notice', permission: 'NOTICE', icon: CampaignIcon },
+        { text: '설정', path: '/settings', permission: 'BUS', icon: SettingsIcon },
+        { text: '사용자 및 권한', path: '/admin/users', permission: 'SUPER_ADMIN', icon: AdminPanelSettingsIcon },
     ]
-    const menuItemClicked = (text: string) => {
-        switch (text) {
-        case '셔틀버스': navigate('/shuttle'); break
-        case '노선버스': navigate('/bus'); break
-        case '전철': navigate('/subway'); break
-        case '학식': navigate('/cafeteria'); break
-        case '열람실': navigate('/readingRoom'); break
-        case '연락처': navigate('/contact'); break
-        case '학사일정': navigate('/calendar'); break
-        case '공지사항': navigate('/notice'); break
-        case '설정': navigate('/settings'); break
-        }
+    const menuItems = allMenuItems.filter((item) =>
+        hasPermission(userInfoStore.permissions, item.permission))
+    const menuItemClicked = (path: string) => {
+        navigate(path)
         drawerOpenedStore.setDrawerOpened(false)
     }
     if (isAuthenticatedStore.isAuthenticated === null) {
@@ -153,13 +154,13 @@ export default function Home() {
                     <Toolbar />
                     <Box sx={{ overflow: 'auto' }}>
                         <List>
-                            {menuTexts.map((text, index) => (
-                                <ListItem key={text} disablePadding>
-                                    <ListItemButton onClick={() => menuItemClicked(text)}>
+                            {menuItems.map((item) => (
+                                <ListItem key={item.path} disablePadding>
+                                    <ListItemButton onClick={() => menuItemClicked(item.path)}>
                                         <ListItemIcon>
-                                            {createElement(menuIcons[index])}
+                                            {createElement(item.icon)}
                                         </ListItemIcon>
-                                        <ListItemText primary={text} />
+                                        <ListItemText primary={item.text} />
                                     </ListItemButton>
                                 </ListItem>
                             ))}

--- a/src/routes/permissionRoute.tsx
+++ b/src/routes/permissionRoute.tsx
@@ -1,0 +1,20 @@
+import { PropsWithChildren } from 'react'
+import { Navigate } from 'react-router-dom'
+
+import { AdminPermission, firstAllowedPath, hasPermission } from '../security/permissions.ts'
+import { useUserInfoStore } from '../stores/auth.ts'
+
+export function PermissionRoute({
+    permission,
+    children,
+}: PropsWithChildren<{ permission: AdminPermission }>) {
+    const permissions = useUserInfoStore((state) => state.permissions)
+    return hasPermission(permissions, permission)
+        ? children
+        : <Navigate replace to={firstAllowedPath(permissions)} />
+}
+
+export function PermissionLanding() {
+    const permissions = useUserInfoStore((state) => state.permissions)
+    return <Navigate replace to={firstAllowedPath(permissions)} />
+}

--- a/src/security/permissions.ts
+++ b/src/security/permissions.ts
@@ -1,0 +1,47 @@
+export const ADMIN_PERMISSIONS = [
+    'SUPER_ADMIN',
+    'SHUTTLE',
+    'BUS',
+    'SUBWAY',
+    'CAFETERIA',
+    'READING_ROOM',
+    'CONTACT',
+    'CALENDAR',
+    'NOTICE',
+] as const
+
+export type AdminPermission = typeof ADMIN_PERMISSIONS[number]
+
+export const MANAGEMENT_PERMISSIONS: ReadonlyArray<{
+    value: Exclude<AdminPermission, 'SUPER_ADMIN'>,
+    label: string,
+}> = [
+    { value: 'SHUTTLE', label: '셔틀버스' },
+    { value: 'BUS', label: '노선버스' },
+    { value: 'SUBWAY', label: '전철' },
+    { value: 'CAFETERIA', label: '학식' },
+    { value: 'READING_ROOM', label: '열람실' },
+    { value: 'CONTACT', label: '연락처' },
+    { value: 'CALENDAR', label: '학사일정' },
+    { value: 'NOTICE', label: '공지사항' },
+]
+
+export const hasPermission = (
+    permissions: ReadonlyArray<AdminPermission>,
+    permission: AdminPermission,
+) => permissions.includes('SUPER_ADMIN') || permissions.includes(permission)
+
+export const firstAllowedPath = (permissions: ReadonlyArray<AdminPermission>) => {
+    const routes: ReadonlyArray<[AdminPermission, string]> = [
+        ['SHUTTLE', '/shuttle/period'],
+        ['BUS', '/bus/route'],
+        ['SUBWAY', '/subway/station'],
+        ['CAFETERIA', '/cafeteria/cafeteria'],
+        ['READING_ROOM', '/readingRoom/room'],
+        ['CONTACT', '/contact/category'],
+        ['CALENDAR', '/calendar/category'],
+        ['NOTICE', '/notice/category'],
+        ['SUPER_ADMIN', '/admin/users'],
+    ]
+    return routes.find(([permission]) => hasPermission(permissions, permission))?.[1] ?? '/access-denied'
+}

--- a/src/service/network/adminUsers.ts
+++ b/src/service/network/adminUsers.ts
@@ -1,0 +1,18 @@
+import client from './client.ts'
+import type { AdminPermission } from '../../security/permissions.ts'
+
+export type AdminUser = {
+    username: string,
+    nickname: string,
+    email: string,
+    phone: string,
+    active: boolean,
+    permissions: AdminPermission[],
+}
+
+export type UpdateAdminUser = Pick<AdminUser, 'active' | 'permissions'>
+
+export const getAdminUsers = async () => client.get<{ result: AdminUser[] }>('/api/v1/admin/users')
+
+export const updateAdminUser = async (username: string, data: UpdateAdminUser) =>
+    client.put<AdminUser>(`/api/v1/admin/users/${encodeURIComponent(username)}`, data)

--- a/src/service/network/client.ts
+++ b/src/service/network/client.ts
@@ -28,7 +28,11 @@ client.interceptors.response.use(
     },
     async (error) => {
         const originalRequest = error.config
-        if (error.response?.status === 403 && !originalRequest._retry) {
+        if (
+            error.response?.status === 401 &&
+            !originalRequest._retry &&
+            !originalRequest.url?.endsWith('/api/v1/user/token')
+        ) {
             originalRequest._retry = true
             // Refresh token
             try {

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -1,5 +1,7 @@
 import { create } from 'zustand'
 
+import { AdminPermission } from '../security/permissions.ts'
+
 type AuthenticatedStore = {
     isAuthenticated: boolean | null,
     setIsAuthenticated: (isAuthenticated: boolean) => void,
@@ -10,7 +12,14 @@ type UserInfoStore = {
     nickname: string | null,
     email: string | null,
     phone: string | null,
-    setUserInfo: (username: string, nickname: string, email: string, phone: string) => void,
+    permissions: AdminPermission[],
+    setUserInfo: (
+        username: string,
+        nickname: string,
+        email: string,
+        phone: string,
+        permissions: AdminPermission[],
+    ) => void,
 }
 
 export const useAuthenticatedStore = create<AuthenticatedStore>((set) => ({
@@ -23,5 +32,7 @@ export const useUserInfoStore = create<UserInfoStore>((set) => ({
     nickname: null,
     email: null,
     phone: null,
-    setUserInfo: (username: string, nickname: string, email: string, phone: string) => set({ username, nickname, email, phone }),
+    permissions: [],
+    setUserInfo: (username, nickname, email, phone, permissions) =>
+        set({ username, nickname, email, phone, permissions }),
 }))


### PR DESCRIPTION
## Summary
- Add a responsive user and permission management page for super administrators.
- Show only management areas granted to the signed-in administrator and guard direct route access.
- Route administrators to their first available area and provide a clear no-permission state.
- Distinguish authentication failures from authorization failures so 403 responses no longer trigger token refresh.
- Prevent the initial profile load from racing permission-based navigation.

## Validation
- `yarn lint` (passes with existing console warnings)
- `yarn build`
- Inspected the permission page at 1440px desktop and 390px mobile widths with mock API data; corrected mobile overflow and verified labels, controls, hierarchy, spacing, and navigation.