### PR TITLE
feat: Add invitation-based account setup

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="referrer" content="no-referrer" />
     <link rel="icon" href="/images/hanyangCharacter.png" type="image/x-icon" />
     <link rel="stylesheet" href="index.css" />
     <title>휴아봇 서비스 관리자 페이지</title>

--- a/src/routes/components/PageLayout.tsx
+++ b/src/routes/components/PageLayout.tsx
@@ -5,6 +5,7 @@ type PageLayoutProps = {
     title: string,
     description?: string,
     icon?: ReactNode,
+    actions?: ReactNode,
     maxWidth?: number,
     children: ReactNode,
 }
@@ -13,6 +14,7 @@ export function PageLayout({
     title,
     description,
     icon,
+    actions,
     maxWidth = 1180,
     children,
 }: PageLayoutProps) {
@@ -27,22 +29,25 @@ export function PageLayout({
                 boxSizing: 'border-box',
                 minWidth: 0,
             }}>
-            <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 2, mb: 3 }}>
-                {icon && (
-                    <Avatar sx={{ bgcolor: 'primary.main', width: 48, height: 48 }}>
-                        {icon}
-                    </Avatar>
-                )}
-                <Box>
-                    <Typography variant='h4' component='h1' fontWeight={750}>
-                        {title}
-                    </Typography>
-                    {description && (
-                        <Typography color='text.secondary' sx={{ mt: 0.5 }}>
-                            {description}
-                        </Typography>
+            <Box sx={{ display: 'flex', alignItems: { xs: 'stretch', sm: 'flex-start' }, gap: 2, mb: 3, flexDirection: { xs: 'column', sm: 'row' } }}>
+                <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 2, flex: 1 }}>
+                    {icon && (
+                        <Avatar sx={{ bgcolor: 'primary.main', width: 48, height: 48 }}>
+                            {icon}
+                        </Avatar>
                     )}
+                    <Box>
+                        <Typography variant='h4' component='h1' fontWeight={750}>
+                            {title}
+                        </Typography>
+                        {description && (
+                            <Typography color='text.secondary' sx={{ mt: 0.5 }}>
+                                {description}
+                            </Typography>
+                        )}
+                    </Box>
                 </Box>
+                {actions && <Box sx={{ flexShrink: 0, '& > *': { width: { xs: '100%', sm: 'auto' } } }}>{actions}</Box>}
             </Box>
             {children}
         </Box>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -6,6 +6,7 @@ import { SectionTabsLayout } from './components/SectionTabsLayout.tsx'
 import type { PageLoader } from './navigation.tsx'
 import { managementSections, standaloneRoutes } from './navigation.tsx'
 import AccessDenied from './pages/accessDenied.tsx'
+import AccountSetup from './pages/accountSetup.tsx'
 import Home from './pages/home.tsx'
 import Login from './pages/login.tsx'
 import { PermissionLanding, PermissionRoute } from './permissionRoute.tsx'
@@ -45,7 +46,9 @@ const appRouter = createBrowserRouter([
             })),
             ...standaloneRoutes.map(({ path, permission, load }) => ({
                 path: path.slice(1),
-                element: <PermissionRoute permission={permission}>{lazyElement(load)}</PermissionRoute>,
+                element: permission
+                    ? <PermissionRoute permission={permission}>{lazyElement(load)}</PermissionRoute>
+                    : lazyElement(load),
             })),
             { path: 'access-denied', element: <AccessDenied /> },
             { index: true, element: <PermissionLanding /> },
@@ -53,6 +56,7 @@ const appRouter = createBrowserRouter([
         ]
     },
     { path: '/login', element: <Login /> },
+    { path: '/account-setup', element: <AccountSetup /> },
 ])
 
 export default function AppRouter() {

--- a/src/routes/navigation.tsx
+++ b/src/routes/navigation.tsx
@@ -19,7 +19,7 @@ export type PageLoader = () => Promise<{ default: ComponentType }>
 export type NavigationItem = {
     label: string,
     path: string,
-    permission: AdminPermission,
+    permission?: AdminPermission,
     icon: SvgIconComponent,
 }
 
@@ -30,6 +30,7 @@ export type ChildRoute = {
 }
 
 export type ManagementSection = NavigationItem & {
+    permission: AdminPermission,
     defaultPath: string,
     children: ChildRoute[],
 }
@@ -146,7 +147,6 @@ export const standaloneRoutes: StandaloneRoute[] = [
     {
         label: '설정',
         path: '/settings',
-        permission: 'BUS',
         icon: SettingsIcon,
         load: () => import('./pages/settings'),
     },
@@ -168,6 +168,6 @@ export const firstAllowedPath = (permissions: ReadonlyArray<AdminPermission>) =>
     const section = managementSections.find(({ permission }) => hasPermission(permissions, permission))
     if (section) return section.defaultPath
 
-    const standaloneRoute = standaloneRoutes.find(({ permission }) => hasPermission(permissions, permission))
+    const standaloneRoute = standaloneRoutes.find(({ permission }) => !permission || hasPermission(permissions, permission))
     return standaloneRoute?.path ?? '/access-denied'
 }

--- a/src/routes/pages/accountSetup.tsx
+++ b/src/routes/pages/accountSetup.tsx
@@ -1,0 +1,138 @@
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline'
+import LockResetOutlinedIcon from '@mui/icons-material/LockResetOutlined'
+import Visibility from '@mui/icons-material/Visibility'
+import VisibilityOff from '@mui/icons-material/VisibilityOff'
+import {
+    Alert,
+    Avatar,
+    Box,
+    Button,
+    CircularProgress,
+    IconButton,
+    InputAdornment,
+    Paper,
+    Stack,
+    TextField,
+    Typography,
+} from '@mui/material'
+import { useEffect, useState } from 'react'
+
+import { completeInvitation, validateInvitation } from '../../service/network/auth.ts'
+
+type SetupState = 'validating' | 'ready' | 'invalid' | 'submitting' | 'complete'
+
+export default function AccountSetup() {
+    const [token] = useState(() => new URLSearchParams(window.location.hash.slice(1)).get('token') ?? '')
+    const [state, setState] = useState<SetupState>('validating')
+    const [password, setPassword] = useState('')
+    const [passwordConfirm, setPasswordConfirm] = useState('')
+    const [showPassword, setShowPassword] = useState(false)
+    const [error, setError] = useState('')
+
+    useEffect(() => {
+        window.history.replaceState({}, '', '/account-setup')
+        if (!token) {
+            setState('invalid')
+            return
+        }
+        void validateInvitation(token)
+            .then((response) => setState(response.data.valid ? 'ready' : 'invalid'))
+            .catch(() => setState('invalid'))
+    }, [token])
+
+    const validPassword = password.length >= 15 && new TextEncoder().encode(password).length <= 72
+    const canSubmit = validPassword && password === passwordConfirm && state === 'ready'
+    const submitting = state === 'submitting'
+
+    const handleSubmit = async () => {
+        if (!canSubmit) return
+        setState('submitting')
+        setError('')
+        try {
+            await completeInvitation(token, password)
+            setState('complete')
+        } catch {
+            setError('초대 링크가 만료되었거나 이미 사용되었습니다.')
+            setState('invalid')
+        }
+    }
+
+    return (
+        <Box sx={{ minHeight: '100dvh', display: 'grid', placeItems: 'center', bgcolor: 'background.default', p: 2 }}>
+            <Paper variant='outlined' sx={{ width: '100%', maxWidth: 480, p: { xs: 3, sm: 4 }, borderRadius: 4 }}>
+                <Stack spacing={3} alignItems='stretch'>
+                    <Stack spacing={1.5} alignItems='center' textAlign='center'>
+                        <Avatar sx={{ width: 56, height: 56, bgcolor: 'primary.main' }}>
+                            {state === 'complete' ? <CheckCircleOutlineIcon /> : <LockResetOutlinedIcon />}
+                        </Avatar>
+                        <Typography variant='h4' component='h1' fontWeight={750}>
+                            {state === 'complete' ? '계정 설정 완료' : '관리자 계정 시작하기'}
+                        </Typography>
+                        <Typography color='text.secondary'>
+                            {state === 'complete'
+                                ? '새 비밀번호로 로그인할 수 있습니다.'
+                                : '본인만 사용할 안전한 비밀번호를 만들어 주세요.'}
+                        </Typography>
+                    </Stack>
+
+                    {state === 'validating' && (
+                        <Stack alignItems='center' spacing={1.5} sx={{ py: 3 }}>
+                            <CircularProgress size={32} />
+                            <Typography color='text.secondary'>초대 링크 확인 중</Typography>
+                        </Stack>
+                    )}
+
+                    {(state === 'ready' || state === 'submitting') && (
+                        <Stack spacing={2} component='form' onSubmit={(event) => { event.preventDefault(); void handleSubmit() }}>
+                            <Alert severity='info'>15자 이상, UTF-8 기준 72바이트 이하로 입력하세요.</Alert>
+                            <TextField
+                                autoFocus
+                                label='새 비밀번호'
+                                type={showPassword ? 'text' : 'password'}
+                                value={password}
+                                onChange={(event) => setPassword(event.target.value)}
+                                error={password.length > 0 && !validPassword}
+                                helperText={password.length > 0 && !validPassword ? '비밀번호 길이 조건을 확인하세요.' : ' '}
+                                autoComplete='new-password'
+                                slotProps={{
+                                    input: {
+                                        endAdornment: (
+                                            <InputAdornment position='end'>
+                                                <IconButton aria-label='비밀번호 표시 전환' onClick={() => setShowPassword((value) => !value)} edge='end'>
+                                                    {showPassword ? <VisibilityOff /> : <Visibility />}
+                                                </IconButton>
+                                            </InputAdornment>
+                                        ),
+                                    },
+                                }}
+                            />
+                            <TextField
+                                label='새 비밀번호 확인'
+                                type={showPassword ? 'text' : 'password'}
+                                value={passwordConfirm}
+                                onChange={(event) => setPasswordConfirm(event.target.value)}
+                                error={passwordConfirm.length > 0 && password !== passwordConfirm}
+                                helperText={passwordConfirm.length > 0 && password !== passwordConfirm ? '비밀번호가 일치하지 않습니다.' : ' '}
+                                autoComplete='new-password'
+                            />
+                            <Button type='submit' variant='contained' size='large' disabled={!validPassword || password !== passwordConfirm || submitting}>
+                                {submitting ? '계정 활성화 중' : '비밀번호 만들고 활성화'}
+                            </Button>
+                        </Stack>
+                    )}
+
+                    {state === 'invalid' && (
+                        <Stack spacing={2}>
+                            <Alert severity='error'>{error || '유효하지 않거나 만료된 초대 링크입니다.'}</Alert>
+                            <Typography variant='body2' color='text.secondary'>관리자에게 새 초대 링크를 요청하세요.</Typography>
+                        </Stack>
+                    )}
+
+                    {state === 'complete' && (
+                        <Button variant='contained' size='large' href='/login'>로그인하러 가기</Button>
+                    )}
+                </Stack>
+            </Paper>
+        </Box>
+    )
+}

--- a/src/routes/pages/admin/users.tsx
+++ b/src/routes/pages/admin/users.tsx
@@ -1,5 +1,8 @@
+import AddOutlinedIcon from '@mui/icons-material/AddOutlined'
 import AdminPanelSettingsOutlinedIcon from '@mui/icons-material/AdminPanelSettingsOutlined'
+import ContentCopyOutlinedIcon from '@mui/icons-material/ContentCopyOutlined'
 import PersonOffOutlinedIcon from '@mui/icons-material/PersonOffOutlined'
+import RefreshOutlinedIcon from '@mui/icons-material/RefreshOutlined'
 import SaveOutlinedIcon from '@mui/icons-material/SaveOutlined'
 import SearchIcon from '@mui/icons-material/Search'
 import {
@@ -13,55 +16,98 @@ import {
     Checkbox,
     Chip,
     CircularProgress,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogTitle,
     Divider,
     FormControl,
     FormControlLabel,
     FormGroup,
     FormLabel,
     InputAdornment,
+    Stack,
     Switch,
     TextField,
+    Typography,
+    useMediaQuery,
 } from '@mui/material'
+import { useTheme } from '@mui/material/styles'
 import axios from 'axios'
 import { useEffect, useMemo, useState } from 'react'
 
-import {
-    MANAGEMENT_PERMISSIONS,
-} from '../../../security/permissions.ts'
+import { MANAGEMENT_PERMISSIONS } from '../../../security/permissions.ts'
 import type { AdminPermission } from '../../../security/permissions.ts'
 import {
+    createAdminUser,
     getAdminUsers,
+    reissueAdminUserInvitation,
     updateAdminUser,
 } from '../../../service/network/adminUsers.ts'
-import type { AdminUser } from '../../../service/network/adminUsers.ts'
+import type {
+    AdminUser,
+    AdminUserInvitation,
+    CreateAdminUser,
+} from '../../../service/network/adminUsers.ts'
 import { AppSnackbar } from '../../components/AppSnackbar.tsx'
 import { PageLayout } from '../../components/PageLayout.tsx'
 import { PageState } from '../../components/PageState.tsx'
 
 type UserDraft = Pick<AdminUser, 'active' | 'permissions'>
 
+const emptyUser: CreateAdminUser = {
+    userID: '',
+    nickname: '',
+    email: '',
+    phone: '',
+    permissions: [],
+}
+
 const sameDraft = (user: AdminUser, draft: UserDraft) =>
     user.active === draft.active &&
     [...user.permissions].sort().join(',') === [...draft.permissions].sort().join(',')
 
+const statusPresentation = (status: AdminUser['status']) => {
+    switch (status) {
+    case 'PENDING_SETUP': return { label: '가입 대기', color: 'warning' as const }
+    case 'INVITATION_EXPIRED': return { label: '초대 만료', color: 'default' as const }
+    case 'ACTIVE': return { label: '활성', color: 'success' as const }
+    case 'INACTIVE': return { label: '비활성', color: 'default' as const }
+    }
+}
+
+const invitationLink = (token: string) =>
+    `${window.location.origin}/account-setup#token=${encodeURIComponent(token)}`
+
 export default function AdminUsers() {
+    const theme = useTheme()
+    const fullScreenDialog = useMediaQuery(theme.breakpoints.down('sm'))
     const [users, setUsers] = useState<AdminUser[]>([])
     const [drafts, setDrafts] = useState<Record<string, UserDraft>>({})
     const [query, setQuery] = useState('')
     const [loading, setLoading] = useState(true)
     const [savingUser, setSavingUser] = useState<string | null>(null)
+    const [reissuingUser, setReissuingUser] = useState<string | null>(null)
     const [error, setError] = useState<string | null>(null)
-    const [saved, setSaved] = useState(false)
+    const [notice, setNotice] = useState('')
+    const [createOpen, setCreateOpen] = useState(false)
+    const [creating, setCreating] = useState(false)
+    const [newUser, setNewUser] = useState<CreateAdminUser>(emptyUser)
+    const [invitation, setInvitation] = useState<AdminUserInvitation | null>(null)
+
+    const syncUsers = (result: AdminUser[]) => {
+        setUsers(result)
+        setDrafts(Object.fromEntries(result.map((user) => [
+            user.username,
+            { active: user.active, permissions: [...user.permissions] },
+        ])))
+    }
 
     const loadUsers = async () => {
         setLoading(true)
         try {
             const response = await getAdminUsers()
-            setUsers(response.data.result)
-            setDrafts(Object.fromEntries(response.data.result.map((user) => [
-                user.username,
-                { active: user.active, permissions: [...user.permissions] },
-            ])))
+            syncUsers(response.data.result)
             setError(null)
         } catch {
             setError('관리자 계정 목록을 불러오지 못했습니다.')
@@ -70,9 +116,7 @@ export default function AdminUsers() {
         }
     }
 
-    useEffect(() => {
-        void loadUsers()
-    }, [])
+    useEffect(() => { void loadUsers() }, [])
 
     const filteredUsers = useMemo(() => {
         const normalizedQuery = query.trim().toLocaleLowerCase()
@@ -97,46 +141,113 @@ export default function AdminUsers() {
         updateDraft(username, { permissions: next })
     }
 
+    const toggleNewUserPermission = (permission: AdminPermission) => {
+        setNewUser((current) => ({
+            ...current,
+            permissions: current.permissions.includes(permission)
+                ? current.permissions.filter((item) => item !== permission)
+                : [...current.permissions, permission],
+        }))
+    }
+
+    const replaceUser = (user: AdminUser) => {
+        setUsers((current) => {
+            const exists = current.some((item) => item.username === user.username)
+            return exists
+                ? current.map((item) => item.username === user.username ? user : item)
+                : [...current, user].sort((left, right) => left.nickname.localeCompare(right.nickname))
+        })
+        setDrafts((current) => ({
+            ...current,
+            [user.username]: { active: user.active, permissions: [...user.permissions] },
+        }))
+    }
+
     const saveUser = async (user: AdminUser) => {
         const draft = drafts[user.username]
         setSavingUser(user.username)
         try {
             const response = await updateAdminUser(user.username, draft)
-            setUsers((current) => current.map((item) =>
-                item.username === user.username ? response.data : item))
-            setDrafts((current) => ({
-                ...current,
-                [user.username]: {
-                    active: response.data.active,
-                    permissions: [...response.data.permissions],
-                },
-            }))
+            replaceUser(response.data)
             setError(null)
-            setSaved(true)
+            setNotice('사용자 권한을 저장했습니다.')
         } catch (requestError: unknown) {
-            const isLastSuperAdmin = axios.isAxiosError<{ message?: string }>(requestError) &&
-                requestError.response?.data?.message === 'LAST_SUPER_ADMIN_REQUIRED'
-            const message = isLastSuperAdmin
+            const messageCode = axios.isAxiosError<{ message?: string }>(requestError)
+                ? requestError.response?.data?.message
+                : undefined
+            setError(messageCode === 'LAST_SUPER_ADMIN_REQUIRED'
                 ? '활성화된 최고 관리자는 최소 한 명 이상 필요합니다.'
-                : '권한 변경을 저장하지 못했습니다.'
-            setError(message)
+                : messageCode === 'USER_SETUP_REQUIRED'
+                    ? '가입 대기 사용자는 비밀번호 설정을 완료해야 활성화됩니다.'
+                    : '권한 변경을 저장하지 못했습니다.')
         } finally {
             setSavingUser(null)
         }
     }
 
+    const handleCreate = async () => {
+        setCreating(true)
+        try {
+            const response = await createAdminUser(newUser)
+            replaceUser(response.data.user)
+            setInvitation(response.data)
+            setCreateOpen(false)
+            setNewUser(emptyUser)
+            setError(null)
+        } catch (requestError: unknown) {
+            const messageCode = axios.isAxiosError<{ message?: string }>(requestError)
+                ? requestError.response?.data?.message
+                : undefined
+            setError(messageCode === 'DUPLICATE_USER_ID'
+                ? '이미 사용 중인 아이디입니다.'
+                : messageCode === 'DUPLICATE_EMAIL'
+                    ? '이미 등록된 이메일입니다.'
+                    : '사용자를 초대하지 못했습니다.')
+        } finally {
+            setCreating(false)
+        }
+    }
+
+    const handleReissue = async (user: AdminUser) => {
+        setReissuingUser(user.username)
+        try {
+            const response = await reissueAdminUserInvitation(user.username)
+            replaceUser(response.data.user)
+            setInvitation(response.data)
+            setError(null)
+        } catch {
+            setError('초대 링크를 재발급하지 못했습니다.')
+        } finally {
+            setReissuingUser(null)
+        }
+    }
+
+    const copyInvitation = async () => {
+        if (!invitation) return
+        try {
+            await navigator.clipboard.writeText(invitationLink(invitation.token))
+            setNotice('초대 링크를 클립보드에 복사했습니다.')
+        } catch {
+            setError('초대 링크를 복사하지 못했습니다. 아래 링크를 직접 복사해 주세요.')
+        }
+    }
+
+    const canCreate = Boolean(newUser.userID.trim() && newUser.nickname.trim() && newUser.email.trim())
+
     return (
         <PageLayout
             title='사용자 및 권한'
-            description='계정을 활성화하고 담당할 관리 영역을 지정합니다.'
-            icon={<AdminPanelSettingsOutlinedIcon />}>
-
+            description='관리자를 초대하고 담당할 관리 영역을 지정합니다.'
+            icon={<AdminPanelSettingsOutlinedIcon />}
+            actions={(
+                <Button variant='contained' startIcon={<AddOutlinedIcon />} onClick={() => setCreateOpen(true)}>
+                    사용자 초대
+                </Button>
+            )}>
             <Alert severity='info' sx={{ mb: 3 }}>
-                최고 관리자는 모든 영역과 사용자 권한을 관리할 수 있습니다. 일반 관리자에게는 필요한 영역만 부여하세요.
+                새 사용자는 초대 링크에서 비밀번호를 만든 뒤 활성화됩니다. 최고 관리자는 모든 영역을 관리할 수 있습니다.
             </Alert>
-
             {error && <Alert severity='error' sx={{ mb: 3 }} onClose={() => setError(null)}>{error}</Alert>}
-
             <TextField
                 value={query}
                 onChange={(event) => setQuery(event.target.value)}
@@ -144,106 +255,68 @@ export default function AdminUsers() {
                 placeholder='이름, 아이디 또는 이메일'
                 fullWidth
                 sx={{ mb: 3, maxWidth: 520 }}
-                slotProps={{
-                    input: {
-                        startAdornment: (
-                            <InputAdornment position='start'><SearchIcon /></InputAdornment>
-                        ),
-                    },
-                }}
+                slotProps={{ input: { startAdornment: <InputAdornment position='start'><SearchIcon /></InputAdornment> } }}
             />
-
             {loading ? (
                 <PageState loading label='관리자 계정 불러오는 중' />
             ) : filteredUsers.length === 0 ? (
-                <PageState
-                    label='검색 결과가 없습니다.'
-                    icon={<PersonOffOutlinedIcon sx={{ fontSize: 48 }} />}
-                />
+                <PageState label='검색 결과가 없습니다.' icon={<PersonOffOutlinedIcon sx={{ fontSize: 48 }} />} />
             ) : (
                 <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', lg: 'repeat(2, 1fr)' }, gap: 2.5 }}>
                     {filteredUsers.map((user) => {
                         const draft = drafts[user.username]
-                        const isSuperAdmin = draft.permissions.includes('SUPER_ADMIN')
-                        const isSaving = savingUser === user.username
+                        const pendingSetup = user.status === 'PENDING_SETUP' || user.status === 'INVITATION_EXPIRED'
+                        const status = statusPresentation(user.status)
                         return (
                             <Card key={user.username} variant='outlined' sx={{ borderRadius: 3 }}>
                                 <CardHeader
-                                    avatar={(
-                                        <Avatar sx={{ bgcolor: 'primary.main', color: 'primary.contrastText' }}>
-                                            {user.nickname.slice(0, 1)}
-                                        </Avatar>
-                                    )}
+                                    avatar={<Avatar sx={{ bgcolor: 'primary.main' }}>{user.nickname.slice(0, 1)}</Avatar>}
                                     title={user.nickname}
                                     subheader={`${user.username} · ${user.email}`}
-                                    action={
-                                        <Chip
-                                            label={draft.active ? '활성' : '비활성'}
-                                            color={draft.active ? 'success' : 'default'}
-                                            size='small'
-                                            sx={{ mt: 1 }}
-                                        />
-                                    }
+                                    action={<Chip label={status.label} color={status.color} size='small' sx={{ mt: 1 }} />}
                                 />
                                 <CardContent sx={{ pt: 0 }}>
-                                    <FormControlLabel
-                                        sx={{ minHeight: 48, mx: 0, width: '100%' }}
-                                        control={
-                                            <Switch
-                                                checked={draft.active}
-                                                onChange={(event) => updateDraft(user.username, { active: event.target.checked })}
-                                                slotProps={{ input: { 'aria-label': `${user.nickname} 계정 활성화` } }}
-                                            />
-                                        }
-                                        label='로그인 및 관리 기능 사용 허용'
-                                    />
-                                    <Divider sx={{ my: 2 }} />
-                                    <FormControl component='fieldset' fullWidth>
-                                        <FormLabel component='legend' sx={{ mb: 1, color: 'text.primary', fontWeight: 700 }}>
-                                            권한 수준
-                                        </FormLabel>
+                                    {pendingSetup ? (
+                                        <Stack spacing={1.5} sx={{ mb: 2 }}>
+                                            <Typography variant='body2' color='text.secondary'>
+                                                비밀번호 설정 전에는 로그인하거나 계정을 활성화할 수 없습니다.
+                                            </Typography>
+                                            <Button
+                                                variant='outlined'
+                                                startIcon={reissuingUser === user.username
+                                                    ? <CircularProgress size={18} color='inherit' />
+                                                    : <RefreshOutlinedIcon />}
+                                                disabled={reissuingUser === user.username}
+                                                onClick={() => handleReissue(user)}>
+                                                초대 링크 재발급
+                                            </Button>
+                                        </Stack>
+                                    ) : (
                                         <FormControlLabel
-                                            sx={{ minHeight: 48, mx: 0 }}
-                                            control={
-                                                <Checkbox
-                                                    checked={isSuperAdmin}
-                                                    onChange={() => togglePermission(user.username, 'SUPER_ADMIN')}
+                                            sx={{ minHeight: 48, mx: 0, width: '100%' }}
+                                            control={(
+                                                <Switch
+                                                    checked={draft.active}
+                                                    onChange={(event) => updateDraft(user.username, { active: event.target.checked })}
+                                                    slotProps={{ input: { 'aria-label': `${user.nickname} 계정 활성화` } }}
                                                 />
-                                            }
-                                            label='최고 관리자'
+                                            )}
+                                            label='로그인 및 관리 기능 사용 허용'
                                         />
-                                        <FormLabel component='legend' sx={{ mt: 2, mb: 1, color: 'text.primary', fontWeight: 700 }}>
-                                            관리 영역
-                                        </FormLabel>
-                                        <FormGroup
-                                            sx={{
-                                                display: 'grid',
-                                                gridTemplateColumns: { xs: '1fr 1fr', sm: 'repeat(4, 1fr)' },
-                                                gap: 0.5,
-                                            }}>
-                                            {MANAGEMENT_PERMISSIONS.map(({ value, label }) => (
-                                                <FormControlLabel
-                                                    key={value}
-                                                    sx={{ minHeight: 48, mx: 0, opacity: isSuperAdmin ? 0.65 : 1 }}
-                                                    control={
-                                                        <Checkbox
-                                                            checked={isSuperAdmin || draft.permissions.includes(value)}
-                                                            disabled={isSuperAdmin}
-                                                            onChange={() => togglePermission(user.username, value)}
-                                                        />
-                                                    }
-                                                    label={label}
-                                                />
-                                            ))}
-                                        </FormGroup>
-                                    </FormControl>
+                                    )}
+                                    <Divider sx={{ my: 2 }} />
+                                    <PermissionFields
+                                        permissions={draft.permissions}
+                                        onToggle={(permission) => togglePermission(user.username, permission)}
+                                    />
                                     <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: 2 }}>
                                         <Button
                                             variant='contained'
-                                            startIcon={isSaving ? <CircularProgress size={18} color='inherit' /> : <SaveOutlinedIcon />}
-                                            disabled={isSaving || sameDraft(user, draft)}
-                                            onClick={() => saveUser(user)}
-                                            sx={{ minHeight: 44 }}>
+                                            startIcon={savingUser === user.username
+                                                ? <CircularProgress size={18} color='inherit' />
+                                                : <SaveOutlinedIcon />}
+                                            disabled={savingUser === user.username || sameDraft(user, draft)}
+                                            onClick={() => saveUser(user)}>
                                             저장
                                         </Button>
                                     </Box>
@@ -254,10 +327,85 @@ export default function AdminUsers() {
                 </Box>
             )}
 
-            <AppSnackbar
-                message={saved ? '사용자 권한을 저장했습니다.' : ''}
-                onClose={() => setSaved(false)}
-            />
+            <Dialog fullScreen={fullScreenDialog} open={createOpen} onClose={() => !creating && setCreateOpen(false)} fullWidth maxWidth='sm'>
+                <DialogTitle>새 사용자 초대</DialogTitle>
+                <DialogContent dividers>
+                    <Stack spacing={2.5} sx={{ pt: 0.5 }}>
+                        <Alert severity='info'>비밀번호는 사용자가 초대 링크에서 직접 설정합니다.</Alert>
+                        <TextField label='아이디' required value={newUser.userID} inputProps={{ maxLength: 20 }} onChange={(e) => setNewUser({ ...newUser, userID: e.target.value })} />
+                        <TextField label='이름' required value={newUser.nickname} inputProps={{ maxLength: 20 }} onChange={(e) => setNewUser({ ...newUser, nickname: e.target.value })} />
+                        <TextField label='이메일' required type='email' value={newUser.email} inputProps={{ maxLength: 50 }} onChange={(e) => setNewUser({ ...newUser, email: e.target.value })} />
+                        <TextField label='전화번호' value={newUser.phone} inputProps={{ maxLength: 15 }} onChange={(e) => setNewUser({ ...newUser, phone: e.target.value })} />
+                        <PermissionFields permissions={newUser.permissions} onToggle={toggleNewUserPermission} />
+                    </Stack>
+                </DialogContent>
+                <DialogActions sx={{ p: 2 }}>
+                    <Button onClick={() => setCreateOpen(false)} disabled={creating}>취소</Button>
+                    <Button variant='contained' onClick={handleCreate} disabled={creating || !canCreate}>
+                        {creating ? '초대 생성 중' : '초대 생성'}
+                    </Button>
+                </DialogActions>
+            </Dialog>
+
+            <Dialog fullScreen={fullScreenDialog} open={invitation !== null} onClose={() => setInvitation(null)} fullWidth maxWidth='sm'>
+                <DialogTitle>초대 링크가 준비되었습니다</DialogTitle>
+                <DialogContent dividers>
+                    <Stack spacing={2}>
+                        <Alert severity='warning'>이 링크는 창을 닫으면 다시 확인할 수 없습니다. 필요한 전달 채널에 지금 복사하세요.</Alert>
+                        <TextField
+                            label='24시간 동안 유효한 초대 링크'
+                            value={invitation ? invitationLink(invitation.token) : ''}
+                            multiline
+                            minRows={3}
+                            fullWidth
+                            slotProps={{ input: { readOnly: true } }}
+                        />
+                    </Stack>
+                </DialogContent>
+                <DialogActions sx={{ p: 2 }}>
+                    <Button onClick={() => setInvitation(null)}>닫기</Button>
+                    <Button variant='contained' startIcon={<ContentCopyOutlinedIcon />} onClick={copyInvitation}>링크 복사</Button>
+                </DialogActions>
+            </Dialog>
+
+            <AppSnackbar message={notice} onClose={() => setNotice('')} />
         </PageLayout>
+    )
+}
+
+function PermissionFields({
+    permissions,
+    onToggle,
+}: {
+    permissions: AdminPermission[],
+    onToggle: (permission: AdminPermission) => void,
+}) {
+    const isSuperAdmin = permissions.includes('SUPER_ADMIN')
+    return (
+        <FormControl component='fieldset' fullWidth>
+            <FormLabel component='legend' sx={{ mb: 1, color: 'text.primary', fontWeight: 700 }}>권한 수준</FormLabel>
+            <FormControlLabel
+                sx={{ minHeight: 48, mx: 0 }}
+                control={<Checkbox checked={isSuperAdmin} onChange={() => onToggle('SUPER_ADMIN')} />}
+                label='최고 관리자'
+            />
+            <FormLabel component='legend' sx={{ mt: 2, mb: 1, color: 'text.primary', fontWeight: 700 }}>관리 영역</FormLabel>
+            <FormGroup sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr 1fr', sm: 'repeat(4, 1fr)' }, gap: 0.5 }}>
+                {MANAGEMENT_PERMISSIONS.map(({ value, label }) => (
+                    <FormControlLabel
+                        key={value}
+                        sx={{ minHeight: 48, mx: 0, opacity: isSuperAdmin ? 0.65 : 1 }}
+                        control={(
+                            <Checkbox
+                                checked={isSuperAdmin || permissions.includes(value)}
+                                disabled={isSuperAdmin}
+                                onChange={() => onToggle(value)}
+                            />
+                        )}
+                        label={label}
+                    />
+                ))}
+            </FormGroup>
+        </FormControl>
     )
 }

--- a/src/routes/pages/home.tsx
+++ b/src/routes/pages/home.tsx
@@ -80,7 +80,7 @@ export default function Home() {
         }
     }, [])
     const menuItems = navigationItems.filter((item) =>
-        hasPermission(userInfoStore.permissions, item.permission))
+        !item.permission || hasPermission(userInfoStore.permissions, item.permission))
     const menuItemClicked = (path: string) => {
         void navigate(path)
         setMobileDrawerOpen(false)

--- a/src/routes/pages/settings/index.tsx
+++ b/src/routes/pages/settings/index.tsx
@@ -1,23 +1,32 @@
+import AccountCircleOutlinedIcon from '@mui/icons-material/AccountCircleOutlined'
 import DarkModeOutlinedIcon from '@mui/icons-material/DarkModeOutlined'
 import LightModeOutlinedIcon from '@mui/icons-material/LightModeOutlined'
+import LockResetOutlinedIcon from '@mui/icons-material/LockResetOutlined'
 import SettingsBrightnessOutlinedIcon from '@mui/icons-material/SettingsBrightnessOutlined'
 import SettingsOutlinedIcon from '@mui/icons-material/SettingsOutlined'
 import Visibility from '@mui/icons-material/Visibility'
 import VisibilityOff from '@mui/icons-material/VisibilityOff'
 import {
+    Alert,
+    Box,
     Button,
     Divider,
     IconButton,
     InputAdornment,
     Paper,
+    Stack,
     TextField,
     ToggleButton,
     ToggleButtonGroup,
     Typography,
 } from '@mui/material'
 import { useColorScheme } from '@mui/material/styles'
+import axios from 'axios'
 import { useState } from 'react'
+import type { MouseEvent, ReactNode } from 'react'
 
+import { changePassword, updateProfile } from '../../../service/network/auth.ts'
+import { useUserInfoStore } from '../../../stores/auth.ts'
 import { AppSnackbar } from '../../components/AppSnackbar.tsx'
 import { PageLayout } from '../../components/PageLayout.tsx'
 
@@ -26,90 +35,176 @@ type ThemeMode = 'light' | 'dark' | 'system'
 
 export default function Settings() {
     const { mode, setMode } = useColorScheme()
+    const userInfo = useUserInfoStore()
+    const [nickname, setNickname] = useState(userInfo.nickname ?? '')
+    const [email, setEmail] = useState(userInfo.email ?? '')
+    const [phone, setPhone] = useState(userInfo.phone ?? '')
+    const [profileSaving, setProfileSaving] = useState(false)
+    const [currentPassword, setCurrentPassword] = useState('')
+    const [newPassword, setNewPassword] = useState('')
+    const [passwordConfirm, setPasswordConfirm] = useState('')
+    const [passwordSaving, setPasswordSaving] = useState(false)
+    const [showPassword, setShowPassword] = useState(false)
     const [apiKey, setApiKey] = useState(localStorage.getItem(GBIS_API_KEY_STORAGE_KEY) ?? '')
     const [showKey, setShowKey] = useState(false)
-    const [saved, setSaved] = useState(false)
+    const [notice, setNotice] = useState('')
+    const [error, setError] = useState('')
 
-    const handleSave = () => {
-        if (apiKey.trim()) {
-            localStorage.setItem(GBIS_API_KEY_STORAGE_KEY, apiKey.trim())
-        } else {
-            localStorage.removeItem(GBIS_API_KEY_STORAGE_KEY)
+    const handleProfileSave = async () => {
+        setProfileSaving(true)
+        setError('')
+        try {
+            const response = await updateProfile({ nickname, email, phone })
+            const profile = response.data
+            userInfo.setUserInfo(profile.username, profile.nickname, profile.email, profile.phone, profile.permissions)
+            setNickname(profile.nickname)
+            setEmail(profile.email)
+            setPhone(profile.phone)
+            setNotice('내 정보를 저장했습니다.')
+        } catch (requestError: unknown) {
+            const duplicateEmail = axios.isAxiosError<{ message?: string }>(requestError) &&
+                requestError.response?.data?.message === 'DUPLICATE_EMAIL'
+            setError(duplicateEmail ? '이미 등록된 이메일입니다.' : '내 정보를 저장하지 못했습니다.')
+        } finally {
+            setProfileSaving(false)
         }
-        setSaved(true)
     }
-    const handleThemeChange = (_event: React.MouseEvent<HTMLElement>, nextMode: ThemeMode | null) => {
-        if (nextMode !== null) {
-            setMode(nextMode)
+
+    const validNewPassword = newPassword.length >= 15 && new TextEncoder().encode(newPassword).length <= 72
+    const handlePasswordChange = async () => {
+        setPasswordSaving(true)
+        setError('')
+        try {
+            await changePassword(currentPassword, newPassword)
+            window.location.assign('/login')
+        } catch (requestError: unknown) {
+            const wrongPassword = axios.isAxiosError<{ message?: string }>(requestError) &&
+                requestError.response?.data?.message === 'CURRENT_PASSWORD_MISMATCH'
+            setError(wrongPassword ? '현재 비밀번호가 일치하지 않습니다.' : '비밀번호를 변경하지 못했습니다.')
+        } finally {
+            setPasswordSaving(false)
         }
+    }
+
+    const handleApiKeySave = () => {
+        if (apiKey.trim()) localStorage.setItem(GBIS_API_KEY_STORAGE_KEY, apiKey.trim())
+        else localStorage.removeItem(GBIS_API_KEY_STORAGE_KEY)
+        setNotice('API 키를 저장했습니다.')
+    }
+
+    const handleThemeChange = (_event: MouseEvent<HTMLElement>, nextMode: ThemeMode | null) => {
+        if (nextMode !== null) setMode(nextMode)
     }
 
     return (
         <PageLayout
             title='설정'
-            description='관리 도구에서 사용하는 연결 정보를 관리합니다.'
+            description='내 계정과 관리 도구의 화면 및 연결 정보를 관리합니다.'
             icon={<SettingsOutlinedIcon />}
-            maxWidth={680}>
-            <Paper sx={{ p: 3, mt: 2 }}>
-                <Typography variant='subtitle1' fontWeight='bold' gutterBottom>
-                    화면 테마
-                </Typography>
-                <Divider sx={{ mb: 2 }} />
+            maxWidth={760}>
+            {error && <Alert severity='error' sx={{ mb: 2 }} onClose={() => setError('')}>{error}</Alert>}
+
+            <SettingsCard icon={<AccountCircleOutlinedIcon />} title='내 정보'>
+                <Stack spacing={2}>
+                    <TextField label='아이디' value={userInfo.username ?? ''} disabled fullWidth />
+                    <TextField label='이름' required value={nickname} inputProps={{ maxLength: 20 }} onChange={(event) => setNickname(event.target.value)} fullWidth />
+                    <TextField label='이메일' required type='email' value={email} inputProps={{ maxLength: 50 }} onChange={(event) => setEmail(event.target.value)} fullWidth />
+                    <TextField label='전화번호' value={phone} inputProps={{ maxLength: 15 }} onChange={(event) => setPhone(event.target.value)} fullWidth />
+                    <Box><Button variant='contained' disabled={profileSaving || !nickname.trim() || !email.trim()} onClick={handleProfileSave}>{profileSaving ? '저장 중' : '내 정보 저장'}</Button></Box>
+                </Stack>
+            </SettingsCard>
+
+            <SettingsCard icon={<LockResetOutlinedIcon />} title='비밀번호 변경'>
+                <Stack spacing={2}>
+                    <Alert severity='info'>변경 후 모든 기기에서 로그아웃됩니다. 새 비밀번호는 15자 이상이어야 합니다.</Alert>
+                    <TextField
+                        label='현재 비밀번호'
+                        type={showPassword ? 'text' : 'password'}
+                        value={currentPassword}
+                        onChange={(event) => setCurrentPassword(event.target.value)}
+                        autoComplete='current-password'
+                        slotProps={{ input: { endAdornment: <PasswordVisibility show={showPassword} onToggle={() => setShowPassword((value) => !value)} /> } }}
+                    />
+                    <TextField
+                        label='새 비밀번호'
+                        type={showPassword ? 'text' : 'password'}
+                        value={newPassword}
+                        onChange={(event) => setNewPassword(event.target.value)}
+                        autoComplete='new-password'
+                        error={newPassword.length > 0 && !validNewPassword}
+                        helperText={newPassword.length > 0 && !validNewPassword ? '15자 이상, UTF-8 기준 72바이트 이하로 입력하세요.' : ' '}
+                    />
+                    <TextField
+                        label='새 비밀번호 확인'
+                        type={showPassword ? 'text' : 'password'}
+                        value={passwordConfirm}
+                        onChange={(event) => setPasswordConfirm(event.target.value)}
+                        autoComplete='new-password'
+                        error={passwordConfirm.length > 0 && passwordConfirm !== newPassword}
+                        helperText={passwordConfirm.length > 0 && passwordConfirm !== newPassword ? '새 비밀번호가 일치하지 않습니다.' : ' '}
+                    />
+                    <Box>
+                        <Button
+                            variant='contained'
+                            disabled={passwordSaving || !currentPassword || !validNewPassword || newPassword !== passwordConfirm}
+                            onClick={handlePasswordChange}>
+                            {passwordSaving ? '변경 중' : '비밀번호 변경'}
+                        </Button>
+                    </Box>
+                </Stack>
+            </SettingsCard>
+
+            <SettingsCard title='화면 테마'>
                 <Typography variant='body2' color='text.secondary' sx={{ mb: 2 }}>
                     시스템 설정을 선택하면 기기의 화면 모드 변경을 자동으로 따릅니다.
                 </Typography>
-                <ToggleButtonGroup
-                    value={mode ?? 'system'}
-                    onChange={handleThemeChange}
-                    exclusive
-                    fullWidth
-                    aria-label='화면 테마'>
-                    <ToggleButton value='light' aria-label='라이트 테마'>
-                        <LightModeOutlinedIcon sx={{ mr: { xs: 0.75, sm: 1 } }} />
-                        라이트
-                    </ToggleButton>
-                    <ToggleButton value='dark' aria-label='다크 테마'>
-                        <DarkModeOutlinedIcon sx={{ mr: { xs: 0.75, sm: 1 } }} />
-                        다크
-                    </ToggleButton>
-                    <ToggleButton value='system' aria-label='시스템 설정 테마'>
-                        <SettingsBrightnessOutlinedIcon sx={{ mr: { xs: 0.75, sm: 1 } }} />
-                        시스템
-                    </ToggleButton>
+                <ToggleButtonGroup value={mode ?? 'system'} onChange={handleThemeChange} exclusive fullWidth aria-label='화면 테마'>
+                    <ToggleButton value='light' aria-label='라이트 테마'><LightModeOutlinedIcon sx={{ mr: 1 }} />라이트</ToggleButton>
+                    <ToggleButton value='dark' aria-label='다크 테마'><DarkModeOutlinedIcon sx={{ mr: 1 }} />다크</ToggleButton>
+                    <ToggleButton value='system' aria-label='시스템 설정 테마'><SettingsBrightnessOutlinedIcon sx={{ mr: 1 }} />시스템</ToggleButton>
                 </ToggleButtonGroup>
-            </Paper>
-            <Paper sx={{ p: 3, mt: 2 }}>
-                <Typography variant='subtitle1' fontWeight='bold' gutterBottom>
-                    GBIS API 키
-                </Typography>
-                <Divider sx={{ mb: 2 }} />
+            </SettingsCard>
+
+            <SettingsCard title='GBIS API 키'>
                 <Typography variant='body2' color='text.secondary' sx={{ mb: 2 }}>
-                    경기도 버스정보시스템(GBIS) API 키를 입력하세요.
                     키는 브라우저 로컬 스토리지에만 저장되며 서버로 전송되지 않습니다.
                 </Typography>
                 <TextField
                     label='API 키'
                     value={apiKey}
-                    onChange={(e) => setApiKey(e.target.value)}
+                    onChange={(event) => setApiKey(event.target.value)}
                     type={showKey ? 'text' : 'password'}
                     fullWidth
-                    size='small'
                     sx={{ mb: 2 }}
-                    InputProps={{
-                        endAdornment: (
-                            <InputAdornment position='end'>
-                                <IconButton onClick={() => setShowKey((v) => !v)} edge='end'>
-                                    {showKey ? <VisibilityOff /> : <Visibility />}
-                                </IconButton>
-                            </InputAdornment>
-                        ),
-                    }}
+                    slotProps={{ input: { endAdornment: <PasswordVisibility show={showKey} onToggle={() => setShowKey((value) => !value)} label='API 키 표시 전환' /> } }}
                 />
-                <Button variant='contained' onClick={handleSave}>
-                    저장
-                </Button>
-            </Paper>
-            <AppSnackbar message={saved ? '저장되었습니다.' : ''} onClose={() => setSaved(false)} />
+                <Button variant='contained' onClick={handleApiKeySave}>API 키 저장</Button>
+            </SettingsCard>
+
+            <AppSnackbar message={notice} onClose={() => setNotice('')} />
         </PageLayout>
+    )
+}
+
+function SettingsCard({ icon, title, children }: { icon?: ReactNode, title: string, children: ReactNode }) {
+    return (
+        <Paper variant='outlined' sx={{ p: { xs: 2.5, sm: 3 }, mb: 2.5, borderRadius: 3 }}>
+            <Stack direction='row' alignItems='center' spacing={1} sx={{ mb: 1.5 }}>
+                {icon}
+                <Typography variant='subtitle1' fontWeight={750}>{title}</Typography>
+            </Stack>
+            <Divider sx={{ mb: 2.5 }} />
+            {children}
+        </Paper>
+    )
+}
+
+function PasswordVisibility({ show, onToggle, label = '비밀번호 표시 전환' }: { show: boolean, onToggle: () => void, label?: string }) {
+    return (
+        <InputAdornment position='end'>
+            <IconButton aria-label={label} onClick={onToggle} edge='end'>
+                {show ? <VisibilityOff /> : <Visibility />}
+            </IconButton>
+        </InputAdornment>
     )
 }

--- a/src/service/network/adminUsers.ts
+++ b/src/service/network/adminUsers.ts
@@ -7,12 +7,34 @@ export type AdminUser = {
     email: string,
     phone: string,
     active: boolean,
+    status: 'PENDING_SETUP' | 'INVITATION_EXPIRED' | 'ACTIVE' | 'INACTIVE',
+    invitationExpiresAt: string | null,
     permissions: AdminPermission[],
 }
 
 export type UpdateAdminUser = Pick<AdminUser, 'active' | 'permissions'>
 
+export type CreateAdminUser = {
+    userID: string,
+    nickname: string,
+    email: string,
+    phone: string,
+    permissions: AdminPermission[],
+}
+
+export type AdminUserInvitation = {
+    user: AdminUser,
+    token: string,
+    expiresAt: string,
+}
+
 export const getAdminUsers = async () => client.get<{ result: AdminUser[] }>('/api/v1/admin/users')
 
 export const updateAdminUser = async (username: string, data: UpdateAdminUser) =>
     client.put<AdminUser>(`/api/v1/admin/users/${encodeURIComponent(username)}`, data)
+
+export const createAdminUser = async (data: CreateAdminUser) =>
+    client.post<AdminUserInvitation>('/api/v1/admin/users', data)
+
+export const reissueAdminUserInvitation = async (username: string) =>
+    client.post<AdminUserInvitation>(`/api/v1/admin/users/${encodeURIComponent(username)}/invitation`)

--- a/src/service/network/auth.ts
+++ b/src/service/network/auth.ts
@@ -1,5 +1,6 @@
 import client from './client.ts'
-import { ADMIN_PERMISSIONS, AdminPermission } from '../../security/permissions.ts'
+import { ADMIN_PERMISSIONS } from '../../security/permissions.ts'
+import type { AdminPermission } from '../../security/permissions.ts'
 
 export type UserProfile = {
     username: string,
@@ -49,3 +50,15 @@ export const refreshToken = async () => {
 export const logout = async () => {
     return await client.delete('/api/v1/user/token')
 }
+
+export const validateInvitation = async (token: string) =>
+    client.post<{ valid: boolean, expiresAt: string | null }>('/api/v1/user/account-setup/validate', { token })
+
+export const completeInvitation = async (token: string, password: string) =>
+    client.post('/api/v1/user/account-setup/complete', { token, password })
+
+export const updateProfile = async (data: Pick<UserProfile, 'nickname' | 'email' | 'phone'>) =>
+    client.patch<UserProfile>('/api/v1/user/profile', data)
+
+export const changePassword = async (currentPassword: string, newPassword: string) =>
+    client.put('/api/v1/user/password', { currentPassword, newPassword })


### PR DESCRIPTION
## Summary
- Add administrator invitation creation, reissue, status, and one-time link copy flows.
- Add the public account setup page for validating an invitation and creating the initial password.
- Add self-service profile and password settings for every authenticated administrator.
- Keep invitation tokens in the URL fragment so they are not sent in server requests or referrer headers.
- Add responsive setup, account, and user-management states for light and dark themes.

## Validation
- `yarn lint`
- `yarn build`
- Chrome desktop and mobile: invitation creation, account setup, profile update, and password update.
- Verified light and dark themes at desktop and mobile widths.