### PR TITLE
feat: Add operations overview and safe timetable imports

### DIFF
--- a/src/routes/components/TimetableImportPreview.tsx
+++ b/src/routes/components/TimetableImportPreview.tsx
@@ -1,0 +1,81 @@
+import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline'
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
+import EditOutlinedIcon from '@mui/icons-material/EditOutlined'
+import {
+    Alert,
+    Box,
+    Chip,
+    Divider,
+    List,
+    ListItem,
+    ListItemIcon,
+    ListItemText,
+    Paper,
+    Stack,
+    Typography,
+} from '@mui/material'
+import type { ReactNode } from 'react'
+
+import type { TimetableImportChange, TimetableImportPreview } from '../../service/network/timetableImport.ts'
+
+const changePresentation: Record<TimetableImportChange['type'], { label: string, color: 'success' | 'warning' | 'error', icon: ReactNode }> = {
+    CREATE: { label: '추가', color: 'success', icon: <AddCircleOutlineIcon color="success" /> },
+    UPDATE: { label: '변경', color: 'warning', icon: <EditOutlinedIcon color="warning" /> },
+    DELETE: { label: '삭제', color: 'error', icon: <DeleteOutlineIcon color="error" /> },
+}
+
+export function TimetableImportPreviewPanel({ preview }: { preview: TimetableImportPreview }) {
+    return (
+        <Stack spacing={2}>
+            <Alert severity={preview.errors.length > 0 ? 'error' : preview.deleteCount > 0 ? 'warning' : 'info'}>
+                {preview.errors.length > 0
+                    ? '오류를 수정한 뒤 다시 검증해주세요.'
+                    : '아래 변경사항을 확인한 뒤 적용해주세요. 적용은 서버에서 한 번에 처리됩니다.'}
+            </Alert>
+            <Box sx={{ display: 'grid', gridTemplateColumns: { xs: 'repeat(2, 1fr)', sm: 'repeat(4, 1fr)' }, gap: 1 }}>
+                {[
+                    ['추가', preview.createCount, 'success.main'],
+                    ['변경', preview.updateCount, 'warning.main'],
+                    ['삭제', preview.deleteCount, 'error.main'],
+                    ['유지', preview.unchangedCount, 'text.secondary'],
+                ].map(([label, count, color]) => (
+                    <Paper key={String(label)} variant="outlined" sx={{ p: 1.5, textAlign: 'center' }}>
+                        <Typography variant="h5" sx={{ color, fontWeight: 700 }}>{count}</Typography>
+                        <Typography variant="caption" color="text.secondary">{label}</Typography>
+                    </Paper>
+                ))}
+            </Box>
+            {preview.errors.map((issue, index) => (
+                <Alert key={`${issue.code}-${issue.row}-${index}`} severity="error">
+                    {issue.row ? `${issue.row}행 · ` : ''}{issue.message}
+                </Alert>
+            ))}
+            {preview.warnings.map((issue, index) => (
+                <Alert key={`${issue.code}-${index}`} severity="warning">{issue.message}</Alert>
+            ))}
+            {preview.sampleChanges.length > 0 && (
+                <Paper variant="outlined">
+                    <List disablePadding>
+                        {preview.sampleChanges.map((change, index) => {
+                            const presentation = changePresentation[change.type]
+                            return (
+                                <Box key={`${change.type}-${change.identifier}-${index}`}>
+                                    {index > 0 && <Divider />}
+                                    <ListItem alignItems="flex-start">
+                                        <ListItemIcon sx={{ minWidth: 38, mt: 0.5 }}>{presentation.icon}</ListItemIcon>
+                                        <ListItemText
+                                            primary={<Stack direction="row" spacing={1} alignItems="center"><Chip size="small" color={presentation.color} label={presentation.label} /><span>{change.identifier}</span></Stack>}
+                                            secondary={change.before || change.after
+                                                ? `${change.before ?? '없음'} → ${change.after ?? '없음'}`
+                                                : undefined}
+                                        />
+                                    </ListItem>
+                                </Box>
+                            )
+                        })}
+                    </List>
+                </Paper>
+            )}
+        </Stack>
+    )
+}

--- a/src/routes/navigation.tsx
+++ b/src/routes/navigation.tsx
@@ -3,6 +3,7 @@ import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings'
 import CalendarMonthIcon from '@mui/icons-material/CalendarMonth'
 import CampaignIcon from '@mui/icons-material/Campaign'
 import ContactsIcon from '@mui/icons-material/Contacts'
+import DashboardOutlinedIcon from '@mui/icons-material/DashboardOutlined'
 import DepartureBoardIcon from '@mui/icons-material/DepartureBoard'
 import DiningIcon from '@mui/icons-material/Dining'
 import DirectionsBusIcon from '@mui/icons-material/DirectionsBus'
@@ -145,6 +146,12 @@ export const managementSections: ManagementSection[] = [
 
 export const standaloneRoutes: StandaloneRoute[] = [
     {
+        label: '운영 요약',
+        path: '/dashboard',
+        icon: DashboardOutlinedIcon,
+        load: () => import('./pages/dashboard.tsx'),
+    },
+    {
         label: '설정',
         path: '/settings',
         icon: SettingsIcon,
@@ -165,6 +172,7 @@ export const navigationItems: NavigationItem[] = [
 ]
 
 export const firstAllowedPath = (permissions: ReadonlyArray<AdminPermission>) => {
+    if (permissions.length > 0) return '/dashboard'
     const section = managementSections.find(({ permission }) => hasPermission(permissions, permission))
     if (section) return section.defaultPath
 

--- a/src/routes/pages/dashboard.tsx
+++ b/src/routes/pages/dashboard.tsx
@@ -1,0 +1,190 @@
+import ArrowForwardRoundedIcon from '@mui/icons-material/ArrowForwardRounded'
+import CheckCircleOutlineRoundedIcon from '@mui/icons-material/CheckCircleOutlineRounded'
+import ErrorOutlineRoundedIcon from '@mui/icons-material/ErrorOutlineRounded'
+import LaunchRoundedIcon from '@mui/icons-material/LaunchRounded'
+import RefreshRoundedIcon from '@mui/icons-material/RefreshRounded'
+import ScheduleRoundedIcon from '@mui/icons-material/ScheduleRounded'
+import WarningAmberRoundedIcon from '@mui/icons-material/WarningAmberRounded'
+import {
+    Alert,
+    Box,
+    Button,
+    Card,
+    CardActionArea,
+    CardContent,
+    Chip,
+    IconButton,
+    Paper,
+    Skeleton,
+    Stack,
+    Tooltip,
+    Typography,
+} from '@mui/material'
+import { useEffect, useMemo, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+import { hasPermission } from '../../security/permissions.ts'
+import { AdminOverview, AdminServiceStatus, getAdminOverview } from '../../service/network/overview.ts'
+import { useUserInfoStore } from '../../stores/auth.ts'
+import { PageLayout } from '../components/PageLayout.tsx'
+import { managementSections } from '../navigation.tsx'
+
+const statusPresentation = {
+    NORMAL: { label: '정상', color: 'success' as const, icon: <CheckCircleOutlineRoundedIcon color="success" /> },
+    WARNING: { label: '확인 필요', color: 'warning' as const, icon: <WarningAmberRoundedIcon color="warning" /> },
+    ERROR: { label: '오류', color: 'error' as const, icon: <ErrorOutlineRoundedIcon color="error" /> },
+    UNKNOWN: { label: '확인 불가', color: 'default' as const, icon: <ScheduleRoundedIcon color="disabled" /> },
+}
+
+const formatDateTime = (value: string | null) => {
+    if (!value) return '기록 없음'
+    return new Intl.DateTimeFormat('ko-KR', {
+        month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit', second: '2-digit',
+    }).format(new Date(value))
+}
+
+function ServiceCard({ service }: { service: AdminServiceStatus }) {
+    const navigate = useNavigate()
+    const presentation = statusPresentation[service.status]
+    return (
+        <Card variant="outlined" sx={{ height: '100%', bgcolor: 'background.paper' }}>
+            <CardActionArea onClick={() => navigate(service.managementPath)} sx={{ height: '100%', alignItems: 'stretch' }}>
+                <CardContent sx={{ height: '100%', display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+                    <Stack direction="row" alignItems="center" justifyContent="space-between" spacing={1}>
+                        <Stack direction="row" alignItems="center" spacing={1}>
+                            {presentation.icon}
+                            <Typography variant="h6" component="h2">{service.title}</Typography>
+                        </Stack>
+                        <Chip size="small" color={presentation.color} label={presentation.label} />
+                    </Stack>
+                    <Typography color="text.secondary" sx={{ flex: 1 }}>{service.message}</Typography>
+                    {service.lastSuccessAt && (
+                        <Typography variant="caption" color="text.secondary">
+                            마지막 정상 갱신 {formatDateTime(service.lastSuccessAt)}
+                        </Typography>
+                    )}
+                    <Stack direction="row" justifyContent="flex-end" alignItems="center" spacing={0.5} color="primary.main">
+                        <Typography variant="button">관리 화면</Typography>
+                        <ArrowForwardRoundedIcon fontSize="small" />
+                    </Stack>
+                </CardContent>
+            </CardActionArea>
+        </Card>
+    )
+}
+
+export default function Dashboard() {
+    const permissions = useUserInfoStore((state) => state.permissions)
+    const navigate = useNavigate()
+    const [overview, setOverview] = useState<AdminOverview | null>(null)
+    const [loading, setLoading] = useState(true)
+    const [error, setError] = useState('')
+
+    const load = async () => {
+        setLoading(true)
+        setError('')
+        try {
+            const response = await getAdminOverview()
+            setOverview(response.data)
+        } catch (requestError) {
+            setError(requestError instanceof Error ? requestError.message : String(requestError))
+        } finally {
+            setLoading(false)
+        }
+    }
+
+    useEffect(() => { load() }, [])
+
+    const attentionCount = overview?.services.filter((service) => service.status !== 'NORMAL').length ?? 0
+    const quickActions = useMemo(
+        () => managementSections.filter((section) => hasPermission(permissions, section.permission)).slice(0, 6),
+        [permissions],
+    )
+
+    return (
+        <PageLayout title="운영 요약" description="현재 서비스 상태와 자주 사용하는 관리 작업을 확인합니다.">
+            <Stack spacing={3} sx={{ width: '100%', pb: 3 }}>
+                <Paper
+                    variant="outlined"
+                    sx={{
+                        p: { xs: 2.5, md: 3.5 },
+                        background: (theme) => theme.applyStyles('light', {
+                            background: 'linear-gradient(135deg, #f7fbff 0%, #eef5fc 100%)',
+                        }),
+                    }}
+                >
+                    <Stack direction={{ xs: 'column', sm: 'row' }} justifyContent="space-between" gap={2}>
+                        <Box>
+                            <Typography variant="overline" color="primary.main" fontWeight={700}>운영 요약</Typography>
+                            <Typography variant="h4" component="h1" sx={{ mt: 0.5, fontWeight: 750 }}>
+                                {attentionCount > 0 ? `${attentionCount}개 항목을 확인해주세요` : '현재 운영 상태가 정상입니다'}
+                            </Typography>
+                            <Typography color="text.secondary" sx={{ mt: 1 }}>
+                                자동 수집 상태와 오늘 적용되는 셔틀 운행 정보를 한눈에 확인할 수 있습니다.
+                            </Typography>
+                        </Box>
+                        <Stack direction="row" alignItems="flex-start" spacing={1}>
+                            {overview && (
+                                <Button
+                                    variant="outlined"
+                                    startIcon={<LaunchRoundedIcon />}
+                                    href={overview.grafanaURL}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                >
+                                    Grafana
+                                </Button>
+                            )}
+                            <Tooltip title="새로고침">
+                                <span><IconButton onClick={load} disabled={loading} aria-label="운영 상태 새로고침"><RefreshRoundedIcon /></IconButton></span>
+                            </Tooltip>
+                        </Stack>
+                    </Stack>
+                </Paper>
+
+                {error && <Alert severity="error">운영 상태를 불러오지 못했습니다: {error}</Alert>}
+                {overview?.expiringInvitationCount !== null && Boolean(overview?.expiringInvitationCount) && (
+                    <Alert severity="warning" action={<Button onClick={() => navigate('/admin/users')}>사용자 확인</Button>}>
+                        24시간 안에 만료되는 관리자 초대가 {overview?.expiringInvitationCount}개 있습니다.
+                    </Alert>
+                )}
+
+                <Box>
+                    <Typography variant="h5" component="h2" fontWeight={700} sx={{ mb: 1.5 }}>서비스 상태</Typography>
+                    <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', sm: 'repeat(2, minmax(0, 1fr))', xl: 'repeat(4, minmax(0, 1fr))' }, gap: 2 }}>
+                        {loading
+                            ? Array.from({ length: 4 }).map((_, index) => <Skeleton key={index} variant="rounded" height={190} />)
+                            : overview?.services.map((service) => <ServiceCard key={service.id} service={service} />)}
+                    </Box>
+                    {!loading && overview?.services.length === 0 && (
+                        <Alert severity="info">자동 상태를 제공하는 관리 영역이 없습니다. 아래 바로가기를 이용해주세요.</Alert>
+                    )}
+                </Box>
+
+                {quickActions.length > 0 && (
+                    <Box>
+                        <Typography variant="h5" component="h2" fontWeight={700} sx={{ mb: 1.5 }}>빠른 작업</Typography>
+                        <Stack direction="row" flexWrap="wrap" gap={1}>
+                            {quickActions.map((section) => (
+                                <Button
+                                    key={section.path}
+                                    variant="outlined"
+                                    startIcon={<section.icon />}
+                                    onClick={() => navigate(section.defaultPath)}
+                                >
+                                    {section.label} 관리
+                                </Button>
+                            ))}
+                        </Stack>
+                    </Box>
+                )}
+
+                {overview && (
+                    <Typography variant="caption" color="text.secondary" textAlign="right">
+                        마지막 확인 {formatDateTime(overview.checkedAt)}
+                    </Typography>
+                )}
+            </Stack>
+        </PageLayout>
+    )
+}

--- a/src/routes/pages/shuttle/timetable/TimetableImportDialog.tsx
+++ b/src/routes/pages/shuttle/timetable/TimetableImportDialog.tsx
@@ -1,0 +1,146 @@
+import {
+    Alert,
+    Button,
+    CircularProgress,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogTitle,
+    Stack,
+    Typography,
+} from '@mui/material'
+import { useEffect, useState } from 'react'
+import * as XLSX from 'xlsx'
+
+import {
+    applyShuttleTimetableImport,
+    previewShuttleTimetableImport,
+    ShuttleTimetableImportEntry,
+    TimetableImportPreview,
+    TimetableImportResult,
+} from '../../../../service/network/timetableImport.ts'
+import { TimetableImportPreviewPanel } from '../../../components/TimetableImportPreview.tsx'
+
+type Props = {
+    open: boolean,
+    file: File | null,
+    onClose: () => void,
+    onSuccess: (result: TimetableImportResult) => void,
+}
+
+const readField = (row: Record<string, unknown>, names: string[]) => {
+    const key = names.find((name) => row[name] !== undefined)
+    return key ? row[key] : undefined
+}
+
+const parseWeekday = (value: unknown): boolean | null => {
+    if (value === true || value === 1) return true
+    if (value === false || value === 0) return false
+    const normalized = String(value ?? '').trim().toLowerCase()
+    if (['true', 'weekday', 'weekdays', '평일'].includes(normalized)) return true
+    if (['false', 'weekend', 'weekends', '주말', '휴일'].includes(normalized)) return false
+    return null
+}
+
+export function ShuttleTimetableImportDialog({ open, file, onClose, onSuccess }: Props) {
+    const [entries, setEntries] = useState<ShuttleTimetableImportEntry[]>([])
+    const [parseErrors, setParseErrors] = useState<string[]>([])
+    const [preview, setPreview] = useState<TimetableImportPreview | null>(null)
+    const [loading, setLoading] = useState(false)
+    const [requestError, setRequestError] = useState('')
+
+    useEffect(() => {
+        if (!file || !open) return
+        const load = async () => {
+            try {
+                const workbook = XLSX.read(new Uint8Array(await file.arrayBuffer()))
+                const firstSheet = workbook.Sheets[workbook.SheetNames[0]]
+                let rows: Record<string, unknown>[] = []
+                if (firstSheet) {
+                    rows = XLSX.utils.sheet_to_json(firstSheet, { defval: '' })
+                }
+                const errors: string[] = []
+                const parsed = rows.map((row, index) => {
+                    const routeName = String(readField(row, ['routeName', '노선', '노선명']) ?? '').trim()
+                    const period = String(readField(row, ['period', '운행 종류', '운행종류']) ?? '').trim()
+                    const departureTime = String(readField(row, ['departureTime', '출발 시각', '출발시각', '출발 시간']) ?? '').trim()
+                    const weekday = parseWeekday(readField(row, ['weekday', '평일 여부', '평일여부', '요일']))
+                    if (!routeName || !period || !departureTime || weekday === null) {
+                        errors.push(`${index + 2}행의 노선, 운행 종류, 평일 여부 또는 출발 시각을 확인해주세요.`)
+                    }
+                    const isWeekday = weekday === true
+                    return { routeName, period, weekday: isWeekday, departureTime }
+                })
+                setEntries(parsed)
+                setParseErrors(errors)
+                setPreview(null)
+                setRequestError('')
+            } catch (error) {
+                setEntries([])
+                setParseErrors([])
+                setPreview(null)
+                setRequestError(`파일을 읽지 못했습니다: ${error instanceof Error ? error.message : String(error)}`)
+            }
+        }
+        void load()
+    }, [file, open])
+
+    const handlePrimaryAction = async () => {
+        setLoading(true)
+        setRequestError('')
+        try {
+            if (preview?.previewID) {
+                const response = await applyShuttleTimetableImport(preview.previewID)
+                onSuccess(response.data)
+                onClose()
+                return
+            }
+            const routeNames = [...new Set(entries.map((entry) => entry.routeName).filter(Boolean))]
+            const response = await previewShuttleTimetableImport(routeNames, entries)
+            setPreview(response.data)
+        } catch (error) {
+            setRequestError(error instanceof Error ? error.message : String(error))
+            if (preview) setPreview(null)
+        } finally {
+            setLoading(false)
+        }
+    }
+    const primaryDisabled = loading || parseErrors.length > 0 || entries.length === 0 || Boolean(preview && !preview.previewID)
+
+    return (
+        <Dialog open={open} onClose={loading ? undefined : onClose} maxWidth="md" fullWidth>
+            <DialogTitle>셔틀 시간표 일괄 업로드</DialogTitle>
+            <DialogContent dividers>
+                <Stack spacing={2}>
+                    {!preview && (
+                        <Stack spacing={1.5}>
+                            <Alert severity="info">
+                                첫 행에 <strong>routeName, period, weekday, departureTime</strong> 열을 입력해주세요.
+                                한글 열 이름인 노선명, 운행 종류, 평일 여부, 출발 시각도 사용할 수 있습니다.
+                            </Alert>
+                            <Typography color="text.secondary">
+                                {entries.length > 0 ? `${entries.length}건을 읽었습니다.` : '파일에서 읽은 시간표가 없습니다.'}
+                            </Typography>
+                            {parseErrors.map((error) => <Alert key={error} severity="error">{error}</Alert>)}
+                        </Stack>
+                    )}
+                    {preview && <TimetableImportPreviewPanel preview={preview} />}
+                    {requestError && <Alert severity="error">요청에 실패했습니다: {requestError}</Alert>}
+                </Stack>
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={onClose} disabled={loading}>취소</Button>
+                {preview && <Button onClick={() => setPreview(null)} disabled={loading}>파일 확인</Button>}
+                <Button
+                    variant="contained"
+                    color={preview?.deleteCount ? 'error' : 'primary'}
+                    disabled={primaryDisabled}
+                    startIcon={loading ? <CircularProgress size={16} /> : undefined}
+                    onClick={handlePrimaryAction}
+                >
+                    {preview ? '변경사항 적용' : '변경사항 검토'}
+                </Button>
+            </DialogActions>
+        </Dialog>
+    )
+}

--- a/src/routes/pages/shuttle/timetable/toolbar.tsx
+++ b/src/routes/pages/shuttle/timetable/toolbar.tsx
@@ -1,15 +1,18 @@
 import AddIcon from '@mui/icons-material/Add'
-import { Autocomplete, TextField } from '@mui/material'
+import UploadFileIcon from '@mui/icons-material/UploadFile'
+import { Alert, Autocomplete, Snackbar, TextField } from '@mui/material'
 import { GridRowModes, Toolbar, ToolbarButton } from '@mui/x-data-grid'
-import { useEffect } from 'react'
+import { ChangeEvent, useEffect, useRef, useState } from 'react'
 import { v4 as uuidv4 } from 'uuid'
 
+import { ShuttleTimetableImportDialog } from './TimetableImportDialog.tsx'
 import {
     getShuttleRoute,
     getShuttleTimetable,
     ShuttleRouteResponse,
     ShuttleTimetableResponse
 } from '../../../../service/network/shuttle.ts'
+import type { TimetableImportResult } from '../../../../service/network/timetableImport.ts'
 import {
     useShuttleTimetableStore,
     useShuttleTimetableGridModelStore,
@@ -19,6 +22,10 @@ import { reportError } from '../../../../utility/reportError.ts'
 export const GridToolbar = () => {
     const rowStore = useShuttleTimetableStore()
     const rowModesModelStore = useShuttleTimetableGridModelStore()
+    const fileInputRef = useRef<HTMLInputElement>(null)
+    const [importOpen, setImportOpen] = useState(false)
+    const [selectedFile, setSelectedFile] = useState<File | null>(null)
+    const [message, setMessage] = useState('')
     const fetchShuttleRoute = async () => {
         const response = await getShuttleRoute()
         if (response.status === 200) {
@@ -79,8 +86,21 @@ export const GridToolbar = () => {
     useEffect(() => {
         fetchShuttleRoute().catch(reportError)
     }, [])
+    const onFileChange = (event: ChangeEvent<HTMLInputElement>) => {
+        const file = event.target.files?.[0]
+        if (!file) return
+        setSelectedFile(file)
+        setImportOpen(true)
+        event.target.value = ''
+    }
+    const onImportSuccess = (result: TimetableImportResult) => {
+        setMessage(`${result.createCount}건 추가, ${result.deleteCount}건 삭제 완료`)
+        const selectedRoute = useShuttleTimetableStore.getState().selectedRoute
+        if (selectedRoute) fetchShuttleTimetable(selectedRoute).catch(reportError)
+    }
     return (
         <Toolbar style={{ display: 'flex', justifyContent: 'flex-end', marginTop: '10px' }}>
+            <input ref={fileInputRef} type="file" accept=".xlsx,.xls,.csv" hidden onChange={onFileChange} />
             <Autocomplete
                 size="small"
                 disablePortal={true}
@@ -92,6 +112,18 @@ export const GridToolbar = () => {
             <ToolbarButton onClick={addRowButtonClicked}>
                 <AddIcon />
             </ToolbarButton>
+            <ToolbarButton onClick={() => fileInputRef.current?.click()}>
+                <UploadFileIcon />
+            </ToolbarButton>
+            <ShuttleTimetableImportDialog
+                open={importOpen}
+                file={selectedFile}
+                onClose={() => setImportOpen(false)}
+                onSuccess={onImportSuccess}
+            />
+            <Snackbar open={Boolean(message)} autoHideDuration={3000} onClose={() => setMessage('')}>
+                <Alert severity="success" onClose={() => setMessage('')}>{message}</Alert>
+            </Snackbar>
         </Toolbar>
     )
 }

--- a/src/routes/pages/subway/timetable/ExcelMappingDialog.tsx
+++ b/src/routes/pages/subway/timetable/ExcelMappingDialog.tsx
@@ -22,11 +22,14 @@ import * as XLSX from 'xlsx'
 
 import {
     BulkSubwayTimetableCreateRequest,
-    bulkCreateSubwayTimetable,
-    bulkDeleteSubwayTimetable,
-    getSubwayTimetable,
-    SubwayTimetable,
 } from '../../../../service/network/subway.ts'
+import {
+    applySubwayTimetableImport,
+    previewSubwayTimetableImport,
+    TimetableImportPreview,
+    TimetableImportResult,
+} from '../../../../service/network/timetableImport.ts'
+import { TimetableImportPreviewPanel } from '../../../components/TimetableImportPreview.tsx'
 
 const TIMETABLE_SHEET_TYPES = [
     {
@@ -250,21 +253,12 @@ const formatMissingMappings = (label: string, names: string[]) => {
     return `${label}: ${preview}${suffix}`
 }
 
-const toCreateRequest = (timetable: SubwayTimetable): BulkSubwayTimetableCreateRequest => ({
-    stationID: timetable.stationID,
-    startStationID: timetable.startStationID,
-    terminalStationID: timetable.terminalStationID,
-    departureTime: timetable.departureTime,
-    weekday: timetable.weekday,
-    direction: timetable.direction,
-})
-
 export type ExcelMappingDialogProps = {
     open: boolean
     onClose: () => void
     file: File | null
     stations: StationOption[]
-    onSuccess: (result: { deletedCount: number; createdCount: number }) => void
+    onSuccess: (result: TimetableImportResult) => void
 }
 
 export const ExcelMappingDialog = ({
@@ -284,6 +278,7 @@ export const ExcelMappingDialog = ({
     const [loading, setLoading] = useState(false)
     const [snackbarOpen, setSnackbarOpen] = useState(false)
     const [snackbarMessage, setSnackbarMessage] = useState('')
+    const [preview, setPreview] = useState<TimetableImportPreview | null>(null)
 
     useEffect(() => {
         if (!file || !open) return
@@ -298,6 +293,7 @@ export const ExcelMappingDialog = ({
             setStartMappings({})
             setTerminalMappings({})
             setPrefix('')
+            setPreview(null)
         }
         load()
     }, [file, open])
@@ -342,6 +338,21 @@ export const ExcelMappingDialog = ({
     }
 
     const handleSave = async () => {
+        if (preview?.previewID) {
+            setLoading(true)
+            try {
+                const response = await applySubwayTimetableImport(preview.previewID)
+                onSuccess(response.data)
+                onClose()
+            } catch (error) {
+                setSnackbarMessage('시간표 적용에 실패했습니다. 다시 미리보기를 생성해주세요: ' + (error instanceof Error ? error.message : String(error)))
+                setPreview(null)
+                setSnackbarOpen(true)
+            } finally {
+                setLoading(false)
+            }
+            return
+        }
         if (!workbook || !parsedNames || !sheetMappings) return
 
         const missingSheetMappings = TIMETABLE_SHEET_TYPES
@@ -398,35 +409,11 @@ export const ExcelMappingDialog = ({
         }
 
         setLoading(true)
-        let deletedEntries: BulkSubwayTimetableCreateRequest[] = []
-        let didDelete = false
         try {
-            const timetableResponse = await getSubwayTimetable()
-            deletedEntries = (timetableResponse.data.result as SubwayTimetable[])
-                .filter((t) => mappedStationIDs.includes(t.stationID))
-                .map(toCreateRequest)
-            const deletedCount = deletedEntries.length
-
-            await bulkDeleteSubwayTimetable({ stationIDs: mappedStationIDs })
-            didDelete = true
-
-            await bulkCreateSubwayTimetable(allEntries)
-            onSuccess({ deletedCount, createdCount: allEntries.length })
-            onClose()
-        } catch (e) {
-            if (didDelete && deletedEntries.length > 0) {
-                try {
-                    await bulkCreateSubwayTimetable(deletedEntries)
-                    setSnackbarMessage('업로드 실패로 기존 시간표를 복구했습니다: ' + (e instanceof Error ? e.message : String(e)))
-                } catch (restoreError) {
-                    setSnackbarMessage(
-                        '업로드 실패 후 기존 시간표 복구도 실패했습니다: '
-                        + (restoreError instanceof Error ? restoreError.message : String(restoreError))
-                    )
-                }
-            } else {
-                setSnackbarMessage('업로드 실패: ' + (e instanceof Error ? e.message : String(e)))
-            }
+            const response = await previewSubwayTimetableImport(mappedStationIDs, allEntries)
+            setPreview(response.data)
+        } catch (error) {
+            setSnackbarMessage('시간표 검증에 실패했습니다: ' + (error instanceof Error ? error.message : String(error)))
             setSnackbarOpen(true)
         } finally {
             setLoading(false)
@@ -437,83 +424,90 @@ export const ExcelMappingDialog = ({
         <Dialog open={open} onClose={loading ? undefined : onClose} maxWidth="md" fullWidth>
             <DialogTitle>시간표 매핑 및 업로드</DialogTitle>
             <DialogContent dividers>
-                {workbook && sheetMappings && (
-                    <Box sx={{ mb: 3 }}>
-                        <Typography variant="subtitle1" sx={{ mb: 1, fontWeight: 600 }}>시트 매핑</Typography>
-                        <Box sx={{
-                            display: 'grid',
-                            gridTemplateColumns: { xs: '1fr', sm: 'repeat(2, minmax(0, 1fr))' },
-                            gap: 1,
-                        }}>
-                            {TIMETABLE_SHEET_TYPES.map((sheetType) => (
-                                <Autocomplete
-                                    key={sheetType.key}
-                                    size="small"
-                                    options={workbook.SheetNames}
-                                    value={sheetMappings[sheetType.key]}
-                                    onChange={(_, value) => changeSheetMapping(sheetType.key, value ?? '')}
-                                    renderInput={(params) => (
-                                        <TextField
-                                            {...params}
-                                            label={sheetType.label}
-                                            error={!workbook.Sheets[sheetMappings[sheetType.key]]}
-                                        />
-                                    )}
-                                />
-                            ))}
+                {preview && <TimetableImportPreviewPanel preview={preview} />}
+                <Box sx={{ display: preview ? 'none' : 'block' }}>
+                    {workbook && sheetMappings && (
+                        <Box sx={{ mb: 3 }}>
+                            <Typography variant="subtitle1" sx={{ mb: 1, fontWeight: 600 }}>시트 매핑</Typography>
+                            <Box sx={{
+                                display: 'grid',
+                                gridTemplateColumns: { xs: '1fr', sm: 'repeat(2, minmax(0, 1fr))' },
+                                gap: 1,
+                            }}>
+                                {TIMETABLE_SHEET_TYPES.map((sheetType) => (
+                                    <Autocomplete
+                                        key={sheetType.key}
+                                        size="small"
+                                        options={workbook.SheetNames}
+                                        value={sheetMappings[sheetType.key]}
+                                        onChange={(_, value) => changeSheetMapping(sheetType.key, value ?? '')}
+                                        renderInput={(params) => (
+                                            <TextField
+                                                {...params}
+                                                label={sheetType.label}
+                                                error={!workbook.Sheets[sheetMappings[sheetType.key]]}
+                                            />
+                                        )}
+                                    />
+                                ))}
+                            </Box>
                         </Box>
+                    )}
+                    <Box sx={{ mb: 2, display: 'flex', gap: 1, alignItems: 'center' }}>
+                        <TextField
+                            label="노선 접두사 (예: K4, K2)"
+                            value={prefix}
+                            onChange={(e) => setPrefix(e.target.value)}
+                            size="small"
+                            sx={{ width: 220 }}
+                        />
+                        <Button onClick={autoMap} variant="outlined" size="small">
+                            자동 매핑
+                        </Button>
                     </Box>
-                )}
-                <Box sx={{ mb: 2, display: 'flex', gap: 1, alignItems: 'center' }}>
-                    <TextField
-                        label="노선 접두사 (예: K4, K2)"
-                        value={prefix}
-                        onChange={(e) => setPrefix(e.target.value)}
-                        size="small"
-                        sx={{ width: 220 }}
-                    />
-                    <Button onClick={autoMap} variant="outlined" size="small">
-                        자동 매핑
-                    </Button>
+                    {parsedNames && (
+                        <Box>
+                            <MappingSection
+                                title={`역 매핑 (${parsedNames.stationNames.length}개)`}
+                                names={parsedNames.stationNames}
+                                mappings={stationMappings}
+                                stations={stations}
+                                prefix={prefix}
+                                onChange={setStationMappings}
+                            />
+                            <MappingSection
+                                title={`시점역 매핑 (${parsedNames.startNames.length}개)`}
+                                names={parsedNames.startNames}
+                                mappings={startMappings}
+                                stations={stations}
+                                prefix={prefix}
+                                onChange={setStartMappings}
+                            />
+                            <MappingSection
+                                title={`종점역 매핑 (${parsedNames.terminalNames.length}개)`}
+                                names={parsedNames.terminalNames}
+                                mappings={terminalMappings}
+                                stations={stations}
+                                prefix={prefix}
+                                onChange={setTerminalMappings}
+                            />
+                        </Box>
+                    )}
                 </Box>
-                {parsedNames && (
-                    <Box>
-                        <MappingSection
-                            title={`역 매핑 (${parsedNames.stationNames.length}개)`}
-                            names={parsedNames.stationNames}
-                            mappings={stationMappings}
-                            stations={stations}
-                            prefix={prefix}
-                            onChange={setStationMappings}
-                        />
-                        <MappingSection
-                            title={`시점역 매핑 (${parsedNames.startNames.length}개)`}
-                            names={parsedNames.startNames}
-                            mappings={startMappings}
-                            stations={stations}
-                            prefix={prefix}
-                            onChange={setStartMappings}
-                        />
-                        <MappingSection
-                            title={`종점역 매핑 (${parsedNames.terminalNames.length}개)`}
-                            names={parsedNames.terminalNames}
-                            mappings={terminalMappings}
-                            stations={stations}
-                            prefix={prefix}
-                            onChange={setTerminalMappings}
-                        />
-                    </Box>
-                )}
             </DialogContent>
             <DialogActions>
                 <Button onClick={onClose} disabled={loading}>취소</Button>
+                {preview && (
+                    <Button onClick={() => setPreview(null)} disabled={loading}>매핑 수정</Button>
+                )}
                 <Button
                     onClick={handleSave}
                     variant="contained"
-                    disabled={loading || !parsedNames}
+                    color={preview?.deleteCount ? 'error' : 'primary'}
+                    disabled={loading || (!parsedNames && !preview) || (preview !== null && !preview.previewID)}
                     startIcon={loading ? <CircularProgress size={16} /> : undefined}
                 >
-                    저장
+                    {preview ? '변경사항 적용' : '변경사항 검토'}
                 </Button>
             </DialogActions>
             <Snackbar open={snackbarOpen} autoHideDuration={4000} onClose={() => setSnackbarOpen(false)}>

--- a/src/routes/pages/subway/timetable/toolbar.tsx
+++ b/src/routes/pages/subway/timetable/toolbar.tsx
@@ -119,8 +119,8 @@ export const GridToolbar = () => {
         event.target.value = ''
     }
 
-    const handleUploadSuccess = ({ deletedCount, createdCount }: { deletedCount: number; createdCount: number }) => {
-        setSnackbarMessage(`${deletedCount}건 삭제, ${createdCount}건 생성 완료`)
+    const handleUploadSuccess = ({ deleteCount, createCount, updateCount }: { deleteCount: number; createCount: number; updateCount: number }) => {
+        setSnackbarMessage(`${createCount}건 추가, ${updateCount}건 변경, ${deleteCount}건 삭제 완료`)
         setSnackbarSeverity('success')
         setSnackbarOpen(true)
         const { selectedStationID, selectedDirection, selectedWeekday } = useSubwayTimetableStore.getState()

--- a/src/service/network/overview.ts
+++ b/src/service/network/overview.ts
@@ -1,0 +1,20 @@
+import client from './client.ts'
+
+export type AdminServiceStatus = {
+    id: string,
+    title: string,
+    status: 'NORMAL' | 'WARNING' | 'ERROR' | 'UNKNOWN',
+    message: string,
+    lastSuccessAt: string | null,
+    lastFailureAt: string | null,
+    managementPath: string,
+}
+
+export type AdminOverview = {
+    checkedAt: string,
+    services: AdminServiceStatus[],
+    expiringInvitationCount: number | null,
+    grafanaURL: string,
+}
+
+export const getAdminOverview = async () => client.get<AdminOverview>('/api/v1/user/overview')

--- a/src/service/network/timetableImport.ts
+++ b/src/service/network/timetableImport.ts
@@ -1,0 +1,55 @@
+import client from './client.ts'
+import type { BulkSubwayTimetableCreateRequest } from './subway.ts'
+
+export type TimetableImportIssue = {
+    row: number | null,
+    code: string,
+    message: string,
+}
+
+export type TimetableImportChange = {
+    type: 'CREATE' | 'UPDATE' | 'DELETE',
+    identifier: string,
+    before: string | null,
+    after: string | null,
+}
+
+export type TimetableImportPreview = {
+    previewID: string | null,
+    expiresAt: string | null,
+    createCount: number,
+    updateCount: number,
+    deleteCount: number,
+    unchangedCount: number,
+    errors: TimetableImportIssue[],
+    warnings: TimetableImportIssue[],
+    sampleChanges: TimetableImportChange[],
+}
+
+export type TimetableImportResult = Pick<
+    TimetableImportPreview,
+    'createCount' | 'updateCount' | 'deleteCount' | 'unchangedCount'
+>
+
+export type ShuttleTimetableImportEntry = {
+    routeName: string,
+    period: string,
+    weekday: boolean,
+    departureTime: string,
+}
+
+export const previewSubwayTimetableImport = async (
+    stationIDs: string[],
+    entries: BulkSubwayTimetableCreateRequest[],
+) => client.post<TimetableImportPreview>('/api/v1/subway/timetable/import/preview', { stationIDs, entries })
+
+export const applySubwayTimetableImport = async (previewID: string) =>
+    client.post<TimetableImportResult>('/api/v1/subway/timetable/import/apply', { previewID })
+
+export const previewShuttleTimetableImport = async (
+    routeNames: string[],
+    entries: ShuttleTimetableImportEntry[],
+) => client.post<TimetableImportPreview>('/api/v1/shuttle/timetable/import/preview', { routeNames, entries })
+
+export const applyShuttleTimetableImport = async (previewID: string) =>
+    client.post<TimetableImportResult>('/api/v1/shuttle/timetable/import/apply', { previewID })


### PR DESCRIPTION
## Summary
- Add a permission-aware operations overview as the authenticated landing page.
- Present service health, expiring administrator invitations, Grafana access, and relevant quick actions.
- Add a shared review panel showing timetable additions, updates, deletions, unchanged rows, validation errors, and warnings.
- Move subway timetable replacement to the server preview-and-apply flow.
- Add Excel and CSV bulk import for shuttle timetables with Korean and English column names.

## Validation
- `yarn lint`
- `yarn build`
- Chrome desktop (1440x1000): verified hierarchy, spacing, navigation, status colors, and text contrast in light and dark themes.
- Chrome mobile (390x844): verified responsive cards, actions, navigation, spacing, and dark-theme contrast.