### PR TITLE
fix: Handle invalid dashboard timestamps

### DIFF
--- a/src/routes/pages/dashboard.tsx
+++ b/src/routes/pages/dashboard.tsx
@@ -36,11 +36,14 @@ const statusPresentation = {
     UNKNOWN: { label: '확인 불가', color: 'default' as const, icon: <ScheduleRoundedIcon color="disabled" /> },
 }
 
+const dateTimeFormatter = new Intl.DateTimeFormat('ko-KR', {
+    month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit', second: '2-digit',
+})
+
 const formatDateTime = (value: string | null) => {
     if (!value) return '기록 없음'
-    return new Intl.DateTimeFormat('ko-KR', {
-        month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit', second: '2-digit',
-    }).format(new Date(value))
+    const timestamp = Date.parse(value.replace(/\[[^\]]+]$/, ''))
+    return Number.isFinite(timestamp) ? dateTimeFormatter.format(timestamp) : '시각 확인 불가'
 }
 
 function ServiceCard({ service }: { service: AdminServiceStatus }) {


### PR DESCRIPTION
## Summary
- Normalize backend timestamps containing an IANA zone suffix before formatting them.
- Keep valid ISO timestamps unchanged while supporting values such as `+09:00[Asia/Seoul]` in Safari.
- Display a safe fallback instead of crashing the entire operations overview when a timestamp is invalid.

## Root Cause
Safari does not parse the bracketed IANA zone suffix emitted by `ZonedDateTime.toString()`. Passing the resulting invalid date to `Intl.DateTimeFormat.format()` raised a runtime error.

## Validation
- `yarn lint`
- `yarn build`
- Verified that a bracketed `Asia/Seoul` timestamp is normalized to a finite timestamp before formatting.
