### PR TITLE
feat: Add administrator Web Push alerts

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,10 +1,15 @@
 <!doctype html>
-<html lang="en">
+<html lang="ko">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="referrer" content="no-referrer" />
-    <link rel="icon" href="/images/hanyangCharacter.png" type="image/x-icon" />
+    <meta name="theme-color" content="#0B57D0" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-title" content="휴아봇 관리자" />
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <link rel="icon" href="/images/hanyangCharacter.png" type="image/png" />
+    <link rel="apple-touch-icon" href="/images/hanyangCharacter.png" />
     <link rel="stylesheet" href="index.css" />
     <title>휴아봇 서비스 관리자 페이지</title>
   </head>

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,20 @@
+{
+  "id": "/",
+  "name": "휴아봇 관리자",
+  "short_name": "휴아봇 관리자",
+  "description": "휴아봇 서비스 운영 및 관리 대시보드",
+  "lang": "ko-KR",
+  "start_url": "/dashboard",
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#F7F8FA",
+  "theme_color": "#0B57D0",
+  "icons": [
+    {
+      "src": "/images/hanyangCharacter.png",
+      "sizes": "833x833",
+      "type": "image/png",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,30 @@
+self.addEventListener('push', (event) => {
+    let payload = {}
+    try {
+        payload = event.data?.json() ?? {}
+    } catch {
+        payload = { body: event.data?.text() }
+    }
+
+    event.waitUntil(self.registration.showNotification(payload.title ?? '휴아봇 운영 알림', {
+        body: payload.body ?? '새로운 운영 상태를 확인해주세요.',
+        icon: '/images/hanyangCharacter.png',
+        badge: '/images/hanyangCharacter.png',
+        tag: payload.tag ?? 'hyuabot-operations',
+        renotify: true,
+        data: { url: payload.url ?? '/dashboard' },
+    }))
+})
+
+self.addEventListener('notificationclick', (event) => {
+    event.notification.close()
+    const targetUrl = new URL(event.notification.data?.url ?? '/dashboard', self.location.origin).href
+    event.waitUntil(self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then((clients) => {
+        const client = clients.find((candidate) => candidate.url.startsWith(self.location.origin))
+        if (client) {
+            client.navigate(targetUrl)
+            return client.focus()
+        }
+        return self.clients.openWindow(targetUrl)
+    }))
+})

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,13 @@ import { Global } from '@emotion/react'
 import { CssBaseline, InitColorSchemeScript, ThemeProvider } from '@mui/material'
 import { createRoot } from 'react-dom/client'
 
+import { registerOperationalServiceWorker } from './pwa/push.ts'
 import Router from './routes'
 import { globalStyle } from './styles/globalStyle.ts'
 import { globalTheme } from './styles/globalTheme.ts'
+
+registerOperationalServiceWorker().catch(() => undefined)
+
 const rootElement = document.getElementById('root')
 if (rootElement === null) {
     throw new Error('Root element was not found')

--- a/src/pwa/push.ts
+++ b/src/pwa/push.ts
@@ -1,0 +1,86 @@
+import {
+    getPushPublicKey,
+    getPushSubscriptionStatus,
+    registerPushSubscription,
+    removePushSubscription,
+} from '../service/network/adminPush.ts'
+
+export type PushAvailability = 'available' | 'denied' | 'install-required' | 'unsupported'
+
+type NavigatorWithStandalone = Navigator & { standalone?: boolean }
+
+export class PushSetupError extends Error {
+    constructor(public readonly reason: 'denied' | 'invalid-subscription') {
+        super(reason)
+    }
+}
+
+export const registerOperationalServiceWorker = async () => {
+    if ('serviceWorker' in navigator) {
+        await navigator.serviceWorker.register('/sw.js')
+    }
+}
+
+export const getPushAvailability = (): PushAvailability => {
+    if (!('serviceWorker' in navigator) || !('PushManager' in window) || !('Notification' in window)) {
+        return 'unsupported'
+    }
+
+    const isAppleMobile = /iPad|iPhone|iPod/.test(navigator.userAgent)
+    const isStandalone = window.matchMedia('(display-mode: standalone)').matches ||
+        (navigator as NavigatorWithStandalone).standalone === true
+    if (isAppleMobile && !isStandalone) return 'install-required'
+    if (Notification.permission === 'denied') return 'denied'
+    return 'available'
+}
+
+export const getCurrentSubscription = async () => {
+    if (getPushAvailability() !== 'available') return null
+    const registration = await navigator.serviceWorker.ready
+    return registration.pushManager.getSubscription()
+}
+
+export const isOperationalPushEnabled = async () => {
+    const subscription = await getCurrentSubscription()
+    if (subscription === null) return false
+    const response = await getPushSubscriptionStatus(subscription.endpoint)
+    return response.data.enabled
+}
+
+export const enableOperationalPush = async () => {
+    const permission = await Notification.requestPermission()
+    if (permission !== 'granted') throw new PushSetupError('denied')
+
+    const registration = await navigator.serviceWorker.ready
+    const existing = await registration.pushManager.getSubscription()
+    const subscription = existing ?? await registration.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey: decodeBase64Url((await getPushPublicKey()).data.publicKey),
+    })
+    const serialized = subscription.toJSON()
+    if (!serialized.endpoint || !serialized.keys?.p256dh || !serialized.keys.auth) {
+        throw new PushSetupError('invalid-subscription')
+    }
+
+    await registerPushSubscription({
+        endpoint: serialized.endpoint,
+        keys: {
+            p256dh: serialized.keys.p256dh,
+            auth: serialized.keys.auth,
+        },
+    })
+}
+
+export const disableOperationalPush = async () => {
+    const subscription = await getCurrentSubscription()
+    if (subscription === null) return
+    await removePushSubscription(subscription.endpoint)
+    await subscription.unsubscribe()
+}
+
+const decodeBase64Url = (value: string) => {
+    const padding = '='.repeat((4 - value.length % 4) % 4)
+    const base64 = (value + padding).replace(/-/g, '+').replace(/_/g, '/')
+    const decoded = window.atob(base64)
+    return Uint8Array.from(decoded, (character) => character.charCodeAt(0))
+}

--- a/src/routes/pages/settings/OperationalAlerts.tsx
+++ b/src/routes/pages/settings/OperationalAlerts.tsx
@@ -1,0 +1,111 @@
+import NotificationsActiveOutlinedIcon from '@mui/icons-material/NotificationsActiveOutlined'
+import NotificationsOffOutlinedIcon from '@mui/icons-material/NotificationsOffOutlined'
+import { Alert, Box, Button, CircularProgress, Stack, Typography } from '@mui/material'
+import { useEffect, useState } from 'react'
+
+import { SettingsCard } from './SettingsCard.tsx'
+import {
+    disableOperationalPush,
+    enableOperationalPush,
+    getPushAvailability,
+    isOperationalPushEnabled,
+    PushSetupError,
+} from '../../../pwa/push.ts'
+
+type AlertState = 'checking' | 'disabled' | 'enabled' | 'error'
+
+export function OperationalAlerts() {
+    const availability = getPushAvailability()
+    const [state, setState] = useState<AlertState>('checking')
+
+    useEffect(() => {
+        let active = true
+        if (availability !== 'available') {
+            setState('disabled')
+            return () => { active = false }
+        }
+
+        isOperationalPushEnabled()
+            .then((enabled) => { if (active) setState(enabled ? 'enabled' : 'disabled') })
+            .catch(() => { if (active) setState('error') })
+        return () => { active = false }
+    }, [availability])
+
+    const handleEnable = async () => {
+        setState('checking')
+        try {
+            await enableOperationalPush()
+            setState('enabled')
+        } catch (error: unknown) {
+            setState(error instanceof PushSetupError && error.reason === 'denied' ? 'disabled' : 'error')
+        }
+    }
+
+    const handleDisable = async () => {
+        setState('checking')
+        try {
+            await disableOperationalPush()
+            setState('disabled')
+        } catch {
+            setState('error')
+        }
+    }
+
+    const guidance = getGuidance(availability, state)
+    return (
+        <SettingsCard icon={<NotificationsActiveOutlinedIcon />} title='운영 알림'>
+            <Stack spacing={2}>
+                <Typography variant='body2' color='text.secondary'>
+                    백엔드 또는 수집 작업에 장애가 발생하거나 복구되면 이 기기로 알려드립니다. 상태가 바뀔 때만 전송합니다.
+                </Typography>
+                <Alert severity={guidance.severity} icon={state === 'checking' ? <CircularProgress size={20} /> : undefined}>
+                    {guidance.message}
+                </Alert>
+                <Box>
+                    {state === 'enabled' ? (
+                        <Button
+                            variant='outlined'
+                            color='inherit'
+                            startIcon={<NotificationsOffOutlinedIcon />}
+                            onClick={handleDisable}>
+                            이 기기 알림 끄기
+                        </Button>
+                    ) : (
+                        <Button
+                            variant='contained'
+                            startIcon={<NotificationsActiveOutlinedIcon />}
+                            disabled={availability !== 'available' || state === 'checking'}
+                            onClick={handleEnable}>
+                            {state === 'checking' ? '상태 확인 중' : '이 기기에서 알림 받기'}
+                        </Button>
+                    )}
+                </Box>
+                <Typography variant='caption' color='text.secondary'>
+                    macOS Safari 16.1 이상 또는 홈 화면에 설치한 iOS·iPadOS 16.4 이상에서 사용할 수 있습니다.
+                </Typography>
+            </Stack>
+        </SettingsCard>
+    )
+}
+
+function getGuidance(availability: ReturnType<typeof getPushAvailability>, state: AlertState): {
+    severity: 'error' | 'info' | 'success' | 'warning',
+    message: string,
+} {
+    if (availability === 'install-required') return {
+        severity: 'info',
+        message: 'iPhone 또는 iPad에서는 Safari 공유 메뉴의 “홈 화면에 추가”로 대시보드를 설치한 뒤, 설치된 앱에서 설정을 열어주세요.',
+    }
+    if (availability === 'unsupported') return {
+        severity: 'warning',
+        message: '현재 브라우저는 웹 푸시를 지원하지 않습니다. 지원되는 Safari에서 다시 시도해주세요.',
+    }
+    if (availability === 'denied') return {
+        severity: 'warning',
+        message: '브라우저에서 알림이 차단되어 있습니다. Safari의 웹사이트 설정에서 알림 권한을 허용해주세요.',
+    }
+    if (state === 'checking') return { severity: 'info', message: '이 기기의 알림 설정을 확인하고 있습니다.' }
+    if (state === 'enabled') return { severity: 'success', message: '이 기기에서 운영 알림을 받고 있습니다.' }
+    if (state === 'error') return { severity: 'error', message: '알림 서버에 연결하지 못했습니다. 잠시 후 다시 시도해주세요.' }
+    return { severity: 'info', message: '알림은 이 기기에서 직접 허용한 경우에만 전송됩니다.' }
+}

--- a/src/routes/pages/settings/SettingsCard.tsx
+++ b/src/routes/pages/settings/SettingsCard.tsx
@@ -1,0 +1,15 @@
+import { Divider, Paper, Stack, Typography } from '@mui/material'
+import type { ReactNode } from 'react'
+
+export function SettingsCard({ icon, title, children }: { icon?: ReactNode, title: string, children: ReactNode }) {
+    return (
+        <Paper variant='outlined' sx={{ p: { xs: 2.5, sm: 3 }, mb: 2.5, borderRadius: 3 }}>
+            <Stack direction='row' alignItems='center' spacing={1} sx={{ mb: 1.5 }}>
+                {icon}
+                <Typography variant='subtitle1' fontWeight={750}>{title}</Typography>
+            </Stack>
+            <Divider sx={{ mb: 2.5 }} />
+            {children}
+        </Paper>
+    )
+}

--- a/src/routes/pages/settings/index.tsx
+++ b/src/routes/pages/settings/index.tsx
@@ -10,10 +10,8 @@ import {
     Alert,
     Box,
     Button,
-    Divider,
     IconButton,
     InputAdornment,
-    Paper,
     Stack,
     TextField,
     ToggleButton,
@@ -23,8 +21,10 @@ import {
 import { useColorScheme } from '@mui/material/styles'
 import axios from 'axios'
 import { useState } from 'react'
-import type { MouseEvent, ReactNode } from 'react'
+import type { MouseEvent } from 'react'
 
+import { OperationalAlerts } from './OperationalAlerts.tsx'
+import { SettingsCard } from './SettingsCard.tsx'
 import { isValidPassword, PASSWORD_REQUIREMENTS } from '../../../security/password.ts'
 import { changePassword, updateProfile } from '../../../service/network/auth.ts'
 import { useUserInfoStore } from '../../../stores/auth.ts'
@@ -166,6 +166,8 @@ export default function Settings() {
                 </ToggleButtonGroup>
             </SettingsCard>
 
+            {userInfo.permissions.includes('SUPER_ADMIN') && <OperationalAlerts />}
+
             <SettingsCard title='GBIS API 키'>
                 <Typography variant='body2' color='text.secondary' sx={{ mb: 2 }}>
                     키는 브라우저 로컬 스토리지에만 저장되며 서버로 전송되지 않습니다.
@@ -184,19 +186,6 @@ export default function Settings() {
 
             <AppSnackbar message={notice} onClose={() => setNotice('')} />
         </PageLayout>
-    )
-}
-
-function SettingsCard({ icon, title, children }: { icon?: ReactNode, title: string, children: ReactNode }) {
-    return (
-        <Paper variant='outlined' sx={{ p: { xs: 2.5, sm: 3 }, mb: 2.5, borderRadius: 3 }}>
-            <Stack direction='row' alignItems='center' spacing={1} sx={{ mb: 1.5 }}>
-                {icon}
-                <Typography variant='subtitle1' fontWeight={750}>{title}</Typography>
-            </Stack>
-            <Divider sx={{ mb: 2.5 }} />
-            {children}
-        </Paper>
     )
 }
 

--- a/src/service/network/adminPush.ts
+++ b/src/service/network/adminPush.ts
@@ -1,0 +1,21 @@
+import client from './client.ts'
+
+export type PushSubscriptionPayload = {
+    endpoint: string,
+    keys: {
+        p256dh: string,
+        auth: string,
+    },
+}
+
+export const getPushPublicKey = async () =>
+    client.get<{ publicKey: string }>('/api/v1/user/push/public-key')
+
+export const getPushSubscriptionStatus = async (endpoint: string) =>
+    client.get<{ enabled: boolean }>('/api/v1/user/push/status', { params: { endpoint } })
+
+export const registerPushSubscription = async (subscription: PushSubscriptionPayload) =>
+    client.post('/api/v1/user/push/subscription', subscription)
+
+export const removePushSubscription = async (endpoint: string) =>
+    client.delete('/api/v1/user/push/subscription', { data: { endpoint } })


### PR DESCRIPTION
## Summary

- Make the administrator dashboard installable as a Home Screen PWA with an application manifest and Service Worker.
- Add a SUPER_ADMIN-only operations-alert card to Settings.
- Support explicit per-device Web Push opt-in, status checks, and unsubscribe actions.
- Explain unsupported browsers, blocked notification permission, and the iPhone/iPad Home Screen installation requirement.
- Open the administrator dashboard when an operations notification is selected.

## Impact

Super administrators can opt individual Safari devices into backend and collection-job outage and recovery alerts. Permission is requested only after the administrator selects the enable action.

## Validation

- `yarn lint`
- `yarn build`
- Chrome desktop light theme (1440 px): verified hierarchy, spacing, status color, and text contrast.
- Chrome mobile dark theme (393 px): verified responsive layout, navigation, controls, and text contrast.
