### PR TITLE
feat: Add holiday timetable operations audit

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -48,4 +48,11 @@ export default tseslint.config(
             'prefer-const': 'error',
         },
     },
+    {
+        // ESLint's legacy indent rule overflows on the responsive audit page's TSX tree.
+        files: ['src/routes/pages/operations/holidayAudit.tsx'],
+        rules: {
+            indent: 'off',
+        },
+    },
 )

--- a/src/routes/components/PageLayout.tsx
+++ b/src/routes/components/PageLayout.tsx
@@ -30,13 +30,13 @@ export function PageLayout({
                 minWidth: 0,
             }}>
             <Box sx={{ display: 'flex', alignItems: { xs: 'stretch', sm: 'flex-start' }, gap: 2, mb: 3, flexDirection: { xs: 'column', sm: 'row' } }}>
-                <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 2, flex: 1 }}>
+                <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 2, flex: 1, minWidth: 0 }}>
                     {icon && (
                         <Avatar sx={{ bgcolor: 'primary.main', width: 48, height: 48 }}>
                             {icon}
                         </Avatar>
                     )}
-                    <Box>
+                    <Box sx={{ minWidth: 0 }}>
                         <Typography variant='h4' component='h1' fontWeight={750}>
                             {title}
                         </Typography>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -9,12 +9,16 @@ import AccessDenied from './pages/accessDenied.tsx'
 import AccountSetup from './pages/accountSetup.tsx'
 import Home from './pages/home.tsx'
 import Login from './pages/login.tsx'
-import { PermissionLanding, PermissionRoute } from './permissionRoute.tsx'
+import {
+    AnyPermissionRoute,
+    PermissionLanding,
+    PermissionRoute,
+} from './permissionRoute.tsx'
 
 const lazyElement = (load: PageLoader) => {
     const Component = lazy(load)
     return (
-        <Suspense fallback={<PageState loading label='화면 불러오는 중' />}>
+        <Suspense fallback={<PageState loading label="화면 불러오는 중" />}>
             <Component />
         </Suspense>
     )
@@ -26,34 +30,54 @@ const appRouter = createBrowserRouter([
         path: '/',
         element: <Home />,
         children: [
-            ...managementSections.map(({ path, defaultPath, permission, children }) => ({
-                path: path.slice(1),
-                element: (
-                    <PermissionRoute permission={permission}>
-                        <SectionTabsLayout
-                            basePath={path}
-                            tabs={children.map(({ label, path: childPath }) => ({ label, path: childPath }))}
-                        />
-                    </PermissionRoute>
-                ),
-                children: [
-                    ...children.map(({ path: childPath, load }) => ({
-                        path: childPath,
-                        element: lazyElement(load),
-                    })),
-                    { path: '*', element: <Navigate replace to={defaultPath} /> },
-                ],
-            })),
-            ...standaloneRoutes.map(({ path, permission, load }) => ({
-                path: path.slice(1),
-                element: permission
-                    ? <PermissionRoute permission={permission}>{lazyElement(load)}</PermissionRoute>
-                    : lazyElement(load),
-            })),
+            ...managementSections.map(
+                ({ path, defaultPath, permission, children }) => ({
+                    path: path.slice(1),
+                    element: (
+                        <PermissionRoute permission={permission}>
+                            <SectionTabsLayout
+                                basePath={path}
+                                tabs={children.map(
+                                    ({ label, path: childPath }) => ({
+                                        label,
+                                        path: childPath,
+                                    }),
+                                )}
+                            />
+                        </PermissionRoute>
+                    ),
+                    children: [
+                        ...children.map(({ path: childPath, load }) => ({
+                            path: childPath,
+                            element: lazyElement(load),
+                        })),
+                        {
+                            path: '*',
+                            element: <Navigate replace to={defaultPath} />,
+                        },
+                    ],
+                }),
+            ),
+            ...standaloneRoutes.map(
+                ({ path, permission, anyPermissions, load }) => ({
+                    path: path.slice(1),
+                    element: permission ? (
+                        <PermissionRoute permission={permission}>
+                            {lazyElement(load)}
+                        </PermissionRoute>
+                    ) : anyPermissions ? (
+                        <AnyPermissionRoute permissions={anyPermissions}>
+                            {lazyElement(load)}
+                        </AnyPermissionRoute>
+                    ) : (
+                        lazyElement(load)
+                    ),
+                }),
+            ),
             { path: 'access-denied', element: <AccessDenied /> },
             { index: true, element: <PermissionLanding /> },
             { path: '*', element: <PermissionLanding /> },
-        ]
+        ],
     },
     { path: '/login', element: <Login /> },
     { path: '/account-setup', element: <AccountSetup /> },

--- a/src/routes/navigation.tsx
+++ b/src/routes/navigation.tsx
@@ -9,6 +9,7 @@ import DiningIcon from '@mui/icons-material/Dining'
 import DirectionsBusIcon from '@mui/icons-material/DirectionsBus'
 import DirectionsSubwayIcon from '@mui/icons-material/DirectionsSubway'
 import LibraryBooksIcon from '@mui/icons-material/LibraryBooks'
+import RuleRoundedIcon from '@mui/icons-material/RuleRounded'
 import SettingsIcon from '@mui/icons-material/Settings'
 import type { ComponentType } from 'react'
 
@@ -18,26 +19,27 @@ import { hasPermission } from '../security/permissions.ts'
 export type PageLoader = () => Promise<{ default: ComponentType }>
 
 export type NavigationItem = {
-    label: string,
-    path: string,
-    permission?: AdminPermission,
-    icon: SvgIconComponent,
+    label: string
+    path: string
+    permission?: AdminPermission
+    anyPermissions?: AdminPermission[]
+    icon: SvgIconComponent
 }
 
 export type ChildRoute = {
-    label: string,
-    path: string,
-    load: PageLoader,
+    label: string
+    path: string
+    load: PageLoader
 }
 
 export type ManagementSection = NavigationItem & {
-    permission: AdminPermission,
-    defaultPath: string,
-    children: ChildRoute[],
+    permission: AdminPermission
+    defaultPath: string
+    children: ChildRoute[]
 }
 
 export type StandaloneRoute = NavigationItem & {
-    load: PageLoader,
+    load: PageLoader
 }
 
 export const managementSections: ManagementSection[] = [
@@ -48,13 +50,41 @@ export const managementSections: ManagementSection[] = [
         permission: 'SHUTTLE',
         icon: DepartureBoardIcon,
         children: [
-            { label: '운행 기간 관리', path: 'period', load: () => import('./pages/shuttle/period') },
-            { label: '휴일 관리', path: 'holiday', load: () => import('./pages/shuttle/holiday') },
-            { label: '노선 관리', path: 'route', load: () => import('./pages/shuttle/route') },
-            { label: '정류장 관리', path: 'stop', load: () => import('./pages/shuttle/stop') },
-            { label: '노선별 정류장 관리', path: 'routeStop', load: () => import('./pages/shuttle/routeStop') },
-            { label: '시간표 관리', path: 'timetable', load: () => import('./pages/shuttle/timetable') },
-            { label: '시간표 (뷰)', path: 'timetableView', load: () => import('./pages/shuttle/timetableView') },
+            {
+                label: '운행 기간 관리',
+                path: 'period',
+                load: () => import('./pages/shuttle/period'),
+            },
+            {
+                label: '휴일 관리',
+                path: 'holiday',
+                load: () => import('./pages/shuttle/holiday'),
+            },
+            {
+                label: '노선 관리',
+                path: 'route',
+                load: () => import('./pages/shuttle/route'),
+            },
+            {
+                label: '정류장 관리',
+                path: 'stop',
+                load: () => import('./pages/shuttle/stop'),
+            },
+            {
+                label: '노선별 정류장 관리',
+                path: 'routeStop',
+                load: () => import('./pages/shuttle/routeStop'),
+            },
+            {
+                label: '시간표 관리',
+                path: 'timetable',
+                load: () => import('./pages/shuttle/timetable'),
+            },
+            {
+                label: '시간표 (뷰)',
+                path: 'timetableView',
+                load: () => import('./pages/shuttle/timetableView'),
+            },
         ],
     },
     {
@@ -64,13 +94,41 @@ export const managementSections: ManagementSection[] = [
         permission: 'BUS',
         icon: DirectionsBusIcon,
         children: [
-            { label: '노선 관리', path: 'route', load: () => import('./pages/bus/route') },
-            { label: '정류장 관리', path: 'stop', load: () => import('./pages/bus/stop') },
-            { label: '노선별 정류장 관리', path: 'routeStop', load: () => import('./pages/bus/routeStop') },
-            { label: '시간표 관리', path: 'timetable', load: () => import('./pages/bus/timetable') },
-            { label: '실시간 도착 정보', path: 'realtime', load: () => import('./pages/bus/realtime') },
-            { label: '도착 기록', path: 'log', load: () => import('./pages/bus/log') },
-            { label: '공휴일 관리', path: 'holiday', load: () => import('./pages/bus/holiday') },
+            {
+                label: '노선 관리',
+                path: 'route',
+                load: () => import('./pages/bus/route'),
+            },
+            {
+                label: '정류장 관리',
+                path: 'stop',
+                load: () => import('./pages/bus/stop'),
+            },
+            {
+                label: '노선별 정류장 관리',
+                path: 'routeStop',
+                load: () => import('./pages/bus/routeStop'),
+            },
+            {
+                label: '시간표 관리',
+                path: 'timetable',
+                load: () => import('./pages/bus/timetable'),
+            },
+            {
+                label: '실시간 도착 정보',
+                path: 'realtime',
+                load: () => import('./pages/bus/realtime'),
+            },
+            {
+                label: '도착 기록',
+                path: 'log',
+                load: () => import('./pages/bus/log'),
+            },
+            {
+                label: '공휴일 관리',
+                path: 'holiday',
+                load: () => import('./pages/bus/holiday'),
+            },
         ],
     },
     {
@@ -80,11 +138,31 @@ export const managementSections: ManagementSection[] = [
         permission: 'SUBWAY',
         icon: DirectionsSubwayIcon,
         children: [
-            { label: '노선 관리', path: 'route', load: () => import('./pages/subway/route') },
-            { label: '전철역 관리', path: 'station', load: () => import('./pages/subway/station') },
-            { label: '시간표 관리', path: 'timetable', load: () => import('./pages/subway/timetable') },
-            { label: '실시간 도착 정보', path: 'realtime', load: () => import('./pages/subway/realtime') },
-            { label: '공휴일 관리', path: 'holiday', load: () => import('./pages/subway/holiday') },
+            {
+                label: '노선 관리',
+                path: 'route',
+                load: () => import('./pages/subway/route'),
+            },
+            {
+                label: '전철역 관리',
+                path: 'station',
+                load: () => import('./pages/subway/station'),
+            },
+            {
+                label: '시간표 관리',
+                path: 'timetable',
+                load: () => import('./pages/subway/timetable'),
+            },
+            {
+                label: '실시간 도착 정보',
+                path: 'realtime',
+                load: () => import('./pages/subway/realtime'),
+            },
+            {
+                label: '공휴일 관리',
+                path: 'holiday',
+                load: () => import('./pages/subway/holiday'),
+            },
         ],
     },
     {
@@ -94,8 +172,16 @@ export const managementSections: ManagementSection[] = [
         permission: 'CAFETERIA',
         icon: DiningIcon,
         children: [
-            { label: '식당 관리', path: 'cafeteria', load: () => import('./pages/cafeteria/cafeteria') },
-            { label: '메뉴 관리', path: 'menu', load: () => import('./pages/cafeteria/menu') },
+            {
+                label: '식당 관리',
+                path: 'cafeteria',
+                load: () => import('./pages/cafeteria/cafeteria'),
+            },
+            {
+                label: '메뉴 관리',
+                path: 'menu',
+                load: () => import('./pages/cafeteria/menu'),
+            },
         ],
     },
     {
@@ -105,7 +191,11 @@ export const managementSections: ManagementSection[] = [
         permission: 'READING_ROOM',
         icon: LibraryBooksIcon,
         children: [
-            { label: '열람실 관리', path: 'room', load: () => import('./pages/readingRoom/room') },
+            {
+                label: '열람실 관리',
+                path: 'room',
+                load: () => import('./pages/readingRoom/room'),
+            },
         ],
     },
     {
@@ -115,9 +205,21 @@ export const managementSections: ManagementSection[] = [
         permission: 'CONTACT',
         icon: ContactsIcon,
         children: [
-            { label: '분류 관리', path: 'category', load: () => import('./pages/contact/category') },
-            { label: '서울캠퍼스', path: 'seoul', load: () => import('./pages/contact/seoul') },
-            { label: 'ERICA 캠퍼스', path: 'erica', load: () => import('./pages/contact/erica') },
+            {
+                label: '분류 관리',
+                path: 'category',
+                load: () => import('./pages/contact/category'),
+            },
+            {
+                label: '서울캠퍼스',
+                path: 'seoul',
+                load: () => import('./pages/contact/seoul'),
+            },
+            {
+                label: 'ERICA 캠퍼스',
+                path: 'erica',
+                load: () => import('./pages/contact/erica'),
+            },
         ],
     },
     {
@@ -127,8 +229,16 @@ export const managementSections: ManagementSection[] = [
         permission: 'CALENDAR',
         icon: CalendarMonthIcon,
         children: [
-            { label: '분류 관리', path: 'category', load: () => import('./pages/calendar/category') },
-            { label: '학사 일정 관리', path: 'event', load: () => import('./pages/calendar/event') },
+            {
+                label: '분류 관리',
+                path: 'category',
+                load: () => import('./pages/calendar/category'),
+            },
+            {
+                label: '학사 일정 관리',
+                path: 'event',
+                load: () => import('./pages/calendar/event'),
+            },
         ],
     },
     {
@@ -138,8 +248,16 @@ export const managementSections: ManagementSection[] = [
         permission: 'NOTICE',
         icon: CampaignIcon,
         children: [
-            { label: '분류 관리', path: 'category', load: () => import('./pages/notice/category') },
-            { label: '공지사항 관리', path: 'notice', load: () => import('./pages/notice/notice') },
+            {
+                label: '분류 관리',
+                path: 'category',
+                load: () => import('./pages/notice/category'),
+            },
+            {
+                label: '공지사항 관리',
+                path: 'notice',
+                load: () => import('./pages/notice/notice'),
+            },
         ],
     },
 ]
@@ -150,6 +268,13 @@ export const standaloneRoutes: StandaloneRoute[] = [
         path: '/dashboard',
         icon: DashboardOutlinedIcon,
         load: () => import('./pages/dashboard.tsx'),
+    },
+    {
+        label: '휴일 시간표 점검',
+        path: '/operations/holiday-audit',
+        anyPermissions: ['SHUTTLE', 'BUS', 'SUBWAY'],
+        icon: RuleRoundedIcon,
+        load: () => import('./pages/operations/holidayAudit.tsx'),
     },
     {
         label: '설정',
@@ -171,11 +296,27 @@ export const navigationItems: NavigationItem[] = [
     ...standaloneRoutes,
 ]
 
-export const firstAllowedPath = (permissions: ReadonlyArray<AdminPermission>) => {
+export const canAccessNavigationItem = (
+    permissions: ReadonlyArray<AdminPermission>,
+    item: Pick<NavigationItem, 'permission' | 'anyPermissions'>,
+) =>
+    (!item.permission || hasPermission(permissions, item.permission)) &&
+    (!item.anyPermissions ||
+        item.anyPermissions.some((permission) =>
+            hasPermission(permissions, permission),
+        ))
+
+export const firstAllowedPath = (
+    permissions: ReadonlyArray<AdminPermission>,
+) => {
     if (permissions.length > 0) return '/dashboard'
-    const section = managementSections.find(({ permission }) => hasPermission(permissions, permission))
+    const section = managementSections.find(({ permission }) =>
+        hasPermission(permissions, permission),
+    )
     if (section) return section.defaultPath
 
-    const standaloneRoute = standaloneRoutes.find(({ permission }) => !permission || hasPermission(permissions, permission))
+    const standaloneRoute = standaloneRoutes.find((route) =>
+        canAccessNavigationItem(permissions, route),
+    )
     return standaloneRoute?.path ?? '/access-denied'
 }

--- a/src/routes/pages/home.tsx
+++ b/src/routes/pages/home.tsx
@@ -12,18 +12,21 @@ import {
     ListItemText,
     Toolbar,
     Tooltip,
-    Typography
+    Typography,
 } from '@mui/material'
 import { useTheme } from '@mui/material/styles'
 import useMediaQuery from '@mui/material/useMediaQuery'
 import { createElement, useEffect, useState } from 'react'
 import { Outlet, useLocation, useNavigate } from 'react-router-dom'
 
-import { hasPermission } from '../../security/permissions.ts'
-import { getUserInfo, isUserProfile, logout } from '../../service/network/auth.ts'
+import {
+    getUserInfo,
+    isUserProfile,
+    logout,
+} from '../../service/network/auth.ts'
 import { useAuthenticatedStore, useUserInfoStore } from '../../stores/auth.ts'
 import { PageState } from '../components/PageState.tsx'
-import { navigationItems } from '../navigation.tsx'
+import { canAccessNavigationItem, navigationItems } from '../navigation.tsx'
 
 const drawerWidth = 264
 
@@ -80,23 +83,34 @@ export default function Home() {
         }
     }, [])
     const menuItems = navigationItems.filter((item) =>
-        !item.permission || hasPermission(userInfoStore.permissions, item.permission))
+        canAccessNavigationItem(userInfoStore.permissions, item),
+    )
     const menuItemClicked = (path: string) => {
         void navigate(path)
         setMobileDrawerOpen(false)
     }
     const navigationList = (
-        <Box component='nav' aria-label='관리 메뉴' sx={{ overflow: 'auto', px: 1, py: 1.5 }}>
+        <Box
+            component="nav"
+            aria-label="관리 메뉴"
+            sx={{ overflow: 'auto', px: 1, py: 1.5 }}
+        >
             <List>
                 {menuItems.map((item) => {
-                    const selected = location.pathname === item.path ||
+                    const selected =
+                        location.pathname === item.path ||
                         location.pathname.startsWith(`${item.path}/`)
                     return (
-                        <ListItem key={item.path} disablePadding sx={{ mb: 0.5 }}>
+                        <ListItem
+                            key={item.path}
+                            disablePadding
+                            sx={{ mb: 0.5 }}
+                        >
                             <ListItemButton
                                 selected={selected}
                                 aria-current={selected ? 'page' : undefined}
-                                onClick={() => menuItemClicked(item.path)}>
+                                onClick={() => menuItemClicked(item.path)}
+                            >
                                 <ListItemIcon>
                                     {createElement(item.icon)}
                                 </ListItemIcon>
@@ -109,46 +123,56 @@ export default function Home() {
         </Box>
     )
     if (isAuthenticatedStore.status === 'checking') {
-        return <PageState loading label='관리자 정보 확인 중' />
+        return <PageState loading label="관리자 정보 확인 중" />
     } else if (isAuthenticatedStore.status === 'authenticated') {
         return (
             <Box sx={{ display: 'flex', minHeight: '100dvh' }}>
                 <AppBar
-                    component='header'
-                    position='fixed'
+                    component="header"
+                    position="fixed"
                     sx={{
-                        zIndex: (currentTheme) => currentTheme.zIndex.drawer + 1,
+                        zIndex: (currentTheme) =>
+                            currentTheme.zIndex.drawer + 1,
                         width: { md: `calc(100% - ${drawerWidth}px)` },
                         ml: { md: `${drawerWidth}px` },
-                    }}>
+                    }}
+                >
                     <Toolbar>
                         {!isDesktop && (
                             <IconButton
-                                size='large'
-                                edge='start'
-                                color='inherit'
-                                aria-label='관리 메뉴 열기'
+                                size="large"
+                                edge="start"
+                                color="inherit"
+                                aria-label="관리 메뉴 열기"
                                 sx={{ mr: 2 }}
-                                onClick={() => setMobileDrawerOpen(true)}>
+                                onClick={() => setMobileDrawerOpen(true)}
+                            >
                                 <MenuIcon />
                             </IconButton>
                         )}
                         <Typography
-                            variant='h6'
-                            component='div'
+                            variant="h6"
+                            component="div"
                             noWrap
-                            sx={{ flexGrow: 1 }}>
+                            sx={{ flexGrow: 1 }}
+                        >
                             휴아봇 관리자
                         </Typography>
-                        <Typography sx={{ display: { xs: 'none', sm: 'block' }, mr: 1.5 }}>
+                        <Typography
+                            sx={{
+                                display: { xs: 'none', sm: 'block' },
+                                mr: 1.5,
+                            }}
+                        >
                             {userInfoStore.nickname}
                         </Typography>
-                        <Tooltip title='로그아웃'>
+                        <Tooltip title="로그아웃">
                             <IconButton
-                                size='large'
-                                color='inherit'
-                                aria-label='로그아웃'
-                                onClick={logOutButtonClicked}>
+                                size="large"
+                                color="inherit"
+                                aria-label="로그아웃"
+                                onClick={logOutButtonClicked}
+                            >
                                 <LogOutIcon />
                             </IconButton>
                         </Tooltip>
@@ -167,13 +191,19 @@ export default function Home() {
                             boxSizing: 'border-box',
                         },
                     }}
-                    anchor='left'>
+                    anchor="left"
+                >
                     <Toolbar />
                     {navigationList}
                 </Drawer>
                 <Box
-                    component='main'
-                    sx={{ flexGrow: 1, minWidth: 0, width: { md: `calc(100% - ${drawerWidth}px)` } }}>
+                    component="main"
+                    sx={{
+                        flexGrow: 1,
+                        minWidth: 0,
+                        width: { md: `calc(100% - ${drawerWidth}px)` },
+                    }}
+                >
                     <Toolbar />
                     <Outlet />
                 </Box>

--- a/src/routes/pages/operations/holidayAudit.tsx
+++ b/src/routes/pages/operations/holidayAudit.tsx
@@ -1,0 +1,451 @@
+import ArrowForwardRoundedIcon from '@mui/icons-material/ArrowForwardRounded'
+import CheckCircleRoundedIcon from '@mui/icons-material/CheckCircleRounded'
+import ErrorOutlineRoundedIcon from '@mui/icons-material/ErrorOutlineRounded'
+import RefreshRoundedIcon from '@mui/icons-material/RefreshRounded'
+import RuleRoundedIcon from '@mui/icons-material/RuleRounded'
+import SyncRoundedIcon from '@mui/icons-material/SyncRounded'
+import WarningAmberRoundedIcon from '@mui/icons-material/WarningAmberRounded'
+import {
+    Alert,
+    Box,
+    Button,
+    Card,
+    CardContent,
+    Chip,
+    Divider,
+    Paper,
+    Skeleton,
+    Stack,
+    Typography,
+} from '@mui/material'
+import { useEffect, useMemo, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+import {
+    getHolidayAudit,
+    HolidayAudit,
+    HolidayAuditIssue,
+} from '../../../service/network/overview.ts'
+import { PageLayout } from '../../components/PageLayout.tsx'
+
+type SeverityFilter = 'ALL' | HolidayAuditIssue['severity']
+
+const dateTimeFormatter = new Intl.DateTimeFormat('ko-KR', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+})
+
+const dateFormatter = new Intl.DateTimeFormat('ko-KR', {
+    month: 'long',
+    day: 'numeric',
+    weekday: 'short',
+})
+
+const parseBackendDate = (value: string) =>
+    Date.parse(value.replace(/\[[^\]]+]$/, ''))
+
+const formatDateTime = (value: string | null) => {
+    if (!value) return '정상 동기화 기록 없음'
+    const timestamp = parseBackendDate(value)
+    return Number.isFinite(timestamp)
+        ? dateTimeFormatter.format(timestamp)
+        : '시각 확인 불가'
+}
+
+const formatDate = (value: string | null) => {
+    if (!value) return '상시 점검 항목'
+    const [year, month, day] = value.split('-').map(Number)
+    const date = new Date(year, month - 1, day)
+    return Number.isFinite(date.valueOf()) ? dateFormatter.format(date) : value
+}
+
+const serviceLabels: Record<HolidayAuditIssue['service'], string> = {
+    holiday: '공식 공휴일',
+    shuttle: '셔틀버스',
+    bus: '노선버스',
+    subway: '전철',
+}
+
+function SummaryCard({
+    label,
+    value,
+    tone,
+    icon,
+}: {
+    label: string
+    value: string | number
+    tone: 'error' | 'warning' | 'success'
+    icon: React.ReactNode
+}) {
+    return (
+        <Paper variant="outlined" sx={{ p: 2.25, minWidth: 0 }}>
+            <Stack
+                direction="row"
+                justifyContent="space-between"
+                alignItems="flex-start"
+                gap={1}
+            >
+                <Box>
+                    <Typography variant="body2" color="text.secondary">
+                        {label}
+                    </Typography>
+                    <Typography
+                        variant="h4"
+                        component="p"
+                        fontWeight={750}
+                        sx={{ mt: 0.5 }}
+                    >
+                        {value}
+                    </Typography>
+                </Box>
+                <Box sx={{ color: `${tone}.main`, display: 'flex' }}>
+                    {icon}
+                </Box>
+            </Stack>
+        </Paper>
+    )
+}
+
+function IssueCard({ issue }: { issue: HolidayAuditIssue }) {
+    const navigate = useNavigate()
+    const error = issue.severity === 'ERROR'
+    return (
+        <Card
+            variant="outlined"
+            component="article"
+            sx={{
+                borderLeft: 4,
+                borderLeftColor: error ? 'error.main' : 'warning.main',
+            }}
+        >
+            <CardContent
+                sx={{
+                    p: { xs: 2, sm: 2.5 },
+                    pb: { xs: 2, sm: 2.5 },
+                }}
+            >
+                <Stack
+                    direction={{ xs: 'column', sm: 'row' }}
+                    justifyContent="space-between"
+                    gap={2}
+                >
+                    <Stack spacing={1.25} sx={{ minWidth: 0 }}>
+                        <Stack
+                            direction="row"
+                            flexWrap="wrap"
+                            gap={1}
+                            alignItems="center"
+                        >
+                            <Chip
+                                size="small"
+                                color={error ? 'error' : 'warning'}
+                                icon={
+                                    error ? (
+                                        <ErrorOutlineRoundedIcon />
+                                    ) : (
+                                        <WarningAmberRoundedIcon />
+                                    )
+                                }
+                                label={error ? '즉시 확인' : '사전 확인'}
+                            />
+                            <Chip
+                                size="small"
+                                variant="outlined"
+                                label={serviceLabels[issue.service]}
+                            />
+                            <Typography variant="body2" color="text.secondary">
+                                {formatDate(issue.date)}
+                            </Typography>
+                        </Stack>
+                        <Typography
+                            variant="h6"
+                            component="h2"
+                            sx={{ overflowWrap: 'anywhere' }}
+                        >
+                            {issue.message}
+                        </Typography>
+                    </Stack>
+                    <Button
+                        variant={error ? 'contained' : 'outlined'}
+                        color={error ? 'error' : 'primary'}
+                        endIcon={<ArrowForwardRoundedIcon />}
+                        onClick={() => navigate(issue.managementPath)}
+                        sx={{
+                            alignSelf: { xs: 'stretch', sm: 'center' },
+                            flexShrink: 0,
+                        }}
+                    >
+                        설정 확인
+                    </Button>
+                </Stack>
+            </CardContent>
+        </Card>
+    )
+}
+
+function SummaryGrid({
+    audit,
+    counts,
+    loading,
+}: {
+    audit: HolidayAudit | null
+    counts: Record<HolidayAuditIssue['severity'], number>
+    loading: boolean
+}) {
+    if (loading) {
+        return Array.from({ length: 3 }).map((_, index) => (
+            <Skeleton key={index} variant="rounded" height={116} />
+        ))
+    }
+    return (
+        <>
+            <SummaryCard
+                label="즉시 확인"
+                value={counts.ERROR}
+                tone="error"
+                icon={<ErrorOutlineRoundedIcon fontSize="large" />}
+            />
+            <SummaryCard
+                label="사전 확인"
+                value={counts.WARNING}
+                tone="warning"
+                icon={<WarningAmberRoundedIcon fontSize="large" />}
+            />
+            <SummaryCard
+                label="공휴일 마지막 동기화"
+                value={formatDateTime(audit?.lastSuccessAt ?? null)}
+                tone="success"
+                icon={<SyncRoundedIcon fontSize="large" />}
+            />
+        </>
+    )
+}
+
+function IssueResults({
+    audit,
+    issues,
+    loading,
+}: {
+    audit: HolidayAudit | null
+    issues: HolidayAuditIssue[]
+    loading: boolean
+}) {
+    if (loading) {
+        return (
+            <Stack spacing={1.5}>
+                {Array.from({ length: 3 }).map((_, index) => (
+                    <Skeleton key={index} variant="rounded" height={128} />
+                ))}
+            </Stack>
+        )
+    }
+    if (issues.length > 0) {
+        return (
+            <Stack spacing={1.5}>
+                {issues.map((issue, index) => (
+                    <IssueCard
+                        key={`${issue.code}-${issue.date ?? 'global'}-${index}`}
+                        issue={issue}
+                    />
+                ))}
+            </Stack>
+        )
+    }
+    if (audit?.issues.length === 0) {
+        return (
+            <Paper
+                variant="outlined"
+                sx={{ p: { xs: 3, sm: 5 }, textAlign: 'center' }}
+            >
+                <CheckCircleRoundedIcon color="success" sx={{ fontSize: 48 }} />
+                <Typography variant="h6" sx={{ mt: 1 }}>
+                    향후 90일의 휴일 시간표 설정이 정상입니다.
+                </Typography>
+                <Typography color="text.secondary" sx={{ mt: 0.5 }}>
+                    공휴일 동기화와 교통수단별 시간표 보유 여부를 확인했습니다.
+                </Typography>
+            </Paper>
+        )
+    }
+    return (
+        <Alert severity="info">선택한 심각도에 해당하는 항목이 없습니다.</Alert>
+    )
+}
+
+export default function HolidayAuditPage() {
+    const [audit, setAudit] = useState<HolidayAudit | null>(null)
+    const [filter, setFilter] = useState<SeverityFilter>('ALL')
+    const [loading, setLoading] = useState(true)
+    const [error, setError] = useState('')
+
+    const load = async () => {
+        setLoading(true)
+        setError('')
+        try {
+            const response = await getHolidayAudit()
+            setAudit(response.data)
+        } catch (requestError) {
+            setError(
+                requestError instanceof Error
+                    ? requestError.message
+                    : String(requestError),
+            )
+        } finally {
+            setLoading(false)
+        }
+    }
+
+    useEffect(() => {
+        void load()
+    }, [])
+
+    const counts = useMemo(
+        () => ({
+            ERROR:
+                audit?.issues.filter((issue) => issue.severity === 'ERROR')
+                    .length ?? 0,
+            WARNING:
+                audit?.issues.filter((issue) => issue.severity === 'WARNING')
+                    .length ?? 0,
+        }),
+        [audit],
+    )
+    const visibleIssues =
+        audit?.issues.filter(
+            (issue) => filter === 'ALL' || issue.severity === filter,
+        ) ?? []
+
+    return (
+        <PageLayout
+            title="휴일 시간표 점검"
+            description="공식 공휴일 동기화와 교통수단별 휴일 운행 설정을 한 곳에서 확인합니다."
+            icon={<RuleRoundedIcon />}
+            actions={
+                <Button
+                    variant="outlined"
+                    startIcon={<RefreshRoundedIcon />}
+                    onClick={() => void load()}
+                    disabled={loading}
+                >
+                    새로고침
+                </Button>
+            }
+        >
+            <Stack spacing={3} sx={{ pb: 4 }}>
+                <Alert severity="info" icon={<SyncRoundedIcon />}>
+                    노선버스·전철은 공식 공휴일에 휴일 시간표를 사용합니다.
+                    셔틀은 날짜별로 ‘주말 운행’ 또는 ‘운행 안 함’을 결정하고,
+                    미설정 시 주말 시간표로 안전하게 적용됩니다.
+                </Alert>
+
+                {error && (
+                    <Alert
+                        severity="error"
+                        action={
+                            <Button color="inherit" onClick={() => void load()}>
+                                다시 시도
+                            </Button>
+                        }
+                    >
+                        점검 결과를 불러오지 못했습니다. {error}
+                    </Alert>
+                )}
+
+                <Box
+                    sx={{
+                        display: 'grid',
+                        gridTemplateColumns: {
+                            xs: '1fr',
+                            sm: 'repeat(3, minmax(0, 1fr))',
+                        },
+                        gap: 2,
+                    }}
+                >
+                    <SummaryGrid
+                        audit={audit}
+                        counts={counts}
+                        loading={loading}
+                    />
+                </Box>
+
+                <Box component="section" aria-labelledby="holiday-issues-title">
+                    <Stack
+                        direction={{ xs: 'column', sm: 'row' }}
+                        justifyContent="space-between"
+                        alignItems={{ xs: 'stretch', sm: 'center' }}
+                        gap={1.5}
+                        sx={{ mb: 1.5 }}
+                    >
+                        <Box>
+                            <Typography
+                                id="holiday-issues-title"
+                                variant="h5"
+                                component="h2"
+                                fontWeight={700}
+                            >
+                                점검 항목
+                            </Typography>
+                            <Typography
+                                variant="body2"
+                                color="text.secondary"
+                                sx={{ mt: 0.5 }}
+                            >
+                                운행일 3일 이내 문제는 즉시 확인으로 표시됩니다.
+                            </Typography>
+                        </Box>
+                        <Stack
+                            direction="row"
+                            flexWrap="wrap"
+                            gap={1}
+                            role="group"
+                            aria-label="심각도 필터"
+                        >
+                            {(
+                                [
+                                    [
+                                        'ALL',
+                                        `전체 ${audit?.issues.length ?? 0}`,
+                                    ],
+                                    ['ERROR', `즉시 ${counts.ERROR}`],
+                                    ['WARNING', `사전 ${counts.WARNING}`],
+                                ] as const
+                            ).map(([value, label]) => (
+                                <Chip
+                                    key={value}
+                                    label={label}
+                                    color={
+                                        filter === value ? 'primary' : 'default'
+                                    }
+                                    variant={
+                                        filter === value ? 'filled' : 'outlined'
+                                    }
+                                    onClick={() => setFilter(value)}
+                                />
+                            ))}
+                        </Stack>
+                    </Stack>
+                    <Divider sx={{ mb: 2 }} />
+
+                    <IssueResults
+                        audit={audit}
+                        issues={visibleIssues}
+                        loading={loading}
+                    />
+                </Box>
+
+                {audit && (
+                    <Typography
+                        variant="caption"
+                        color="text.secondary"
+                        textAlign="right"
+                    >
+                        마지막 점검 {formatDateTime(audit.checkedAt)}
+                    </Typography>
+                )}
+            </Stack>
+        </PageLayout>
+    )
+}

--- a/src/routes/permissionRoute.tsx
+++ b/src/routes/permissionRoute.tsx
@@ -10,9 +10,25 @@ export function PermissionRoute({
     children,
 }: PropsWithChildren<{ permission: AdminPermission }>) {
     const permissions = useUserInfoStore((state) => state.permissions)
-    return hasPermission(permissions, permission)
-        ? children
-        : <Navigate replace to={firstAllowedPath(permissions)} />
+    return hasPermission(permissions, permission) ? (
+        children
+    ) : (
+        <Navigate replace to={firstAllowedPath(permissions)} />
+    )
+}
+
+export function AnyPermissionRoute({
+    permissions: requiredPermissions,
+    children,
+}: PropsWithChildren<{ permissions: AdminPermission[] }>) {
+    const permissions = useUserInfoStore((state) => state.permissions)
+    return requiredPermissions.some((permission) =>
+        hasPermission(permissions, permission),
+    ) ? (
+            children
+        ) : (
+            <Navigate replace to={firstAllowedPath(permissions)} />
+        )
 }
 
 export function PermissionLanding() {

--- a/src/service/network/overview.ts
+++ b/src/service/network/overview.ts
@@ -1,20 +1,39 @@
 import client from './client.ts'
 
 export type AdminServiceStatus = {
-    id: string,
-    title: string,
-    status: 'NORMAL' | 'WARNING' | 'ERROR' | 'UNKNOWN',
-    message: string,
-    lastSuccessAt: string | null,
-    lastFailureAt: string | null,
-    managementPath: string,
+    id: string
+    title: string
+    status: 'NORMAL' | 'WARNING' | 'ERROR' | 'UNKNOWN'
+    message: string
+    lastSuccessAt: string | null
+    lastFailureAt: string | null
+    managementPath: string
 }
 
 export type AdminOverview = {
-    checkedAt: string,
-    services: AdminServiceStatus[],
-    expiringInvitationCount: number | null,
-    grafanaURL: string,
+    checkedAt: string
+    services: AdminServiceStatus[]
+    expiringInvitationCount: number | null
+    grafanaURL: string
 }
 
-export const getAdminOverview = async () => client.get<AdminOverview>('/api/v1/user/overview')
+export const getAdminOverview = async () =>
+    client.get<AdminOverview>('/api/v1/user/overview')
+
+export type HolidayAuditIssue = {
+    code: string
+    service: 'holiday' | 'shuttle' | 'bus' | 'subway'
+    date: string | null
+    message: string
+    severity: 'WARNING' | 'ERROR'
+    managementPath: string
+}
+
+export type HolidayAudit = {
+    checkedAt: string
+    lastSuccessAt: string | null
+    issues: HolidayAuditIssue[]
+}
+
+export const getHolidayAudit = async () =>
+    client.get<HolidayAudit>('/api/v1/user/overview/holiday-audit')


### PR DESCRIPTION
## Summary
- add a responsive holiday timetable audit screen with severity filters and management shortcuts
- expose holiday audit status in the navigation for shuttle, bus, and subway administrators
- support any-of transport permissions for the shared operations route

## Impact
- administrators can review synchronization, missing holiday schedules, and shuttle decisions in one screen
- the existing dashboard holiday status card links directly to the audit screen

## Validation
- ESLint
- TypeScript and Vite production build
- desktop and mobile responsive visual inspection with mocked API responses