### PR TITLE
chore: Speed up CI workflows

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -1,15 +1,17 @@
 name: Check project when creating a pull request
 
 on:
-  push:
-    branches-ignore:
-      - main
   pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: code-check-${{ github.event.pull_request.head.ref || github.ref_name }}
+  cancel-in-progress: true
 
 jobs:
   lint:
     name: Check code style
-    runs-on: ['self-hosted', 'X64']
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -21,13 +23,13 @@ jobs:
       - name: Install dependencies
         run: |
           npm install --global yarn@1.22.22
-          yarn install
+          yarn install --frozen-lockfile
       - name: Run lint
         run: yarn lint
   test-build:
     if: github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main'
     name: Build before deploying
-    runs-on: ['self-hosted', 'X64']
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -39,6 +41,6 @@ jobs:
       - name: Install dependencies
         run: |
           npm install --global yarn@1.22.22
-          yarn install
+          yarn install --frozen-lockfile
       - name: Build
         run: yarn build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Build
         run: yarn build
       - name: Upload built files
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: admin-dist
           path: dist
@@ -49,7 +49,7 @@ jobs:
     runs-on: ['self-hosted', 'ARM64', '1st']
     steps:
       - name: Download built files
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: admin-dist
           path: dist

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,10 +7,15 @@ on:
     types:
       - closed
 
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
 jobs:
-  deploy:
-    name: Deploy to server
-    runs-on: ['self-hosted', 'ARM64', '1st']
+  build:
+    name: Build admin page
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -22,7 +27,7 @@ jobs:
       - name: Install dependencies
         run: |
           npm install --global yarn@1.22.22
-          yarn install
+          yarn install --frozen-lockfile
       - name: Generate .env file
         run: |
           echo "VITE_APP_API_URL=$VITE_APP_API_URL">>.env
@@ -30,6 +35,24 @@ jobs:
           VITE_APP_API_URL: ${{ secrets.VITE_APP_API_URL }}
       - name: Build
         run: yarn build
+      - name: Upload built files
+        uses: actions/upload-artifact@v4
+        with:
+          name: admin-dist
+          path: dist
+          if-no-files-found: error
+          retention-days: 1
+
+  deploy:
+    name: Deploy to server
+    needs: build
+    runs-on: ['self-hosted', 'ARM64', '1st']
+    steps:
+      - name: Download built files
+        uses: actions/download-artifact@v4
+        with:
+          name: admin-dist
+          path: dist
       - name: Copy built files to server
         run: |
           cp -r dist/* /home/ubuntu/hyuabot-admin-frontend/


### PR DESCRIPTION
## Summary

- Run lint and pull-request builds on parallel GitHub-hosted runners.
- Cancel stale checks for the same branch and use the lockfile for deterministic installs.
- Build the production admin bundle on a hosted runner, then deploy only the generated artifact from the production runner.
- Prevent deployment when a pull request is closed without being merged.
- Upgrade artifact actions to Node.js 24-based releases.

## Validation

- Parsed all workflow files as YAML.
- Validated the modified workflows with actionlint.
- Ran `yarn lint` and `yarn build` successfully.
- Confirmed every referenced action uses the Node.js 24 runtime.
