### PR TITLE
fix: Open default management pages

### DIFF
--- a/src/routes/components/DataGridPage.tsx
+++ b/src/routes/components/DataGridPage.tsx
@@ -21,8 +21,7 @@ export function DataGridPage({ children }: DataGridPageProps) {
                     minHeight: 0,
                 },
                 '& .MuiDataGrid-root': {
-                    borderBottomLeftRadius: 0,
-                    borderBottomRightRadius: 0,
+                    borderRadius: 0,
                 },
             }}>
             {children}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -47,6 +47,10 @@ const appRouter = createBrowserRouter([
                         </PermissionRoute>
                     ),
                     children: [
+                        {
+                            index: true,
+                            element: <Navigate replace to={defaultPath} />,
+                        },
                         ...children.map(({ path: childPath, load }) => ({
                             path: childPath,
                             element: lazyElement(load),


### PR DESCRIPTION
## Summary

- Redirect each management-section root to its configured default child page.
- Remove DataGrid corner rounding so management grids connect cleanly to the section tabs.

## Root Cause

The sidebar navigated to section roots such as `/shuttle`, but those nested routes had no index element, leaving only the tab bar visible until an administrator selected a child tab. The shared DataGrid wrapper retained the theme's top corner radius, exposing the page background between the tab divider and grid corners.

## Impact

Administrators can open a management section with one sidebar selection, including on mobile, and the tab bar now connects to grid content without rounded background gaps. Direct navigation to a section root also resolves to its default page.

## Validation

- `yarn lint`
- `yarn build`
- `git diff --check`
- Desktop at 1440 × 1000 with mocked API responses
- Mobile at 390 × 844 with mocked API responses
- Verified sidebar navigation resolves `/shuttle` to `/shuttle/period`
- Verified a 1 px tab divider, 0 px DataGrid top corner radius, and no page-level horizontal overflow
